### PR TITLE
tbDeployToolboxes – Make errors visible by using the <strong> markup

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -316,7 +316,7 @@ isError = ~isSuccess & ~isOptional;
 records = tbDealField(records, 'isOk', true);
 for tt = find(isError)
     record = records(tt);
-    fprintf('Error: "%s" had status %d, message "%s"\n', ...
+    fprintf('<strong>Error: "%s" had status %d, message "%s<strong>"\n', ...
         record.name, record.status, strtrim(record.message));
     records(tt).isOk = false;
 end


### PR DESCRIPTION
I've previously overlooked error messages from TbTb (e.g. when there are uncommitted edits), and I think having bold error messages might help with this.