### PR TITLE
BF: This removes the <strong> mark up

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -316,7 +316,7 @@ isError = ~isSuccess & ~isOptional;
 records = tbDealField(records, 'isOk', true);
 for tt = find(isError)
     record = records(tt);
-    fprintf('<strong>Error: "%s" had status %d, message "%s<strong>"\n', ...
+    fprintf('Error: "%s" had status %d, message "%s"\n', ...
         record.name, record.status, strtrim(record.message));
     records(tt).isOk = false;
 end


### PR DESCRIPTION
The <strong> markup works well in the graphical MATLAB interface but not when MATLAB is run in the terminal. In fact, it just looks more confusing.