### PR TITLE
clear existing prefs in sampleStartup

### DIFF
--- a/sampleStartup.m
+++ b/sampleStartup.m
@@ -6,9 +6,12 @@
 % Your startup.m with the correct toolboxToolboxDir, and any Matlab
 % preferences you wish to change for your local machine.
 %
-% 2016 benjamin.heasly@gmail.com
+% This sample is focused on the ToolboxToolbox.  You can include additional
+% startup actions, if you wish.
+%
+% 2016-2017 benjamin.heasly@gmail.com
 
-%% Where is the Toolbox Toolbox installed?
+%% Where is ToolboxToolbox installed?
 
 % a reasonable default, or pick your own
 pathString = userpath();
@@ -35,7 +38,7 @@ try
     cd(apiDir);
     tbResetMatlabPath('full');
 catch err
-    warning('Error setting Toolbox Toolbox path during startup: %s', err.message);
+    warning('Error setting ToolboxToolbox path during startup: %s', err.message);
 end
 
 cd(originalDir);
@@ -49,7 +52,10 @@ end
 
 %% Matlab preferences that control ToolboxToolbox.
 
-% uncomment any or all of these that you wish to change
+% clear old preferences, so we get a predictable starting place.
+rmpref('ToolboxToolbox');
+
+% choose custom preferences below, or leave commented to accept defaults
 
 % % default location for JSON configuration
 % configPath = fullfile(tbUserFolder(), 'toolbox_config.json');
@@ -71,11 +77,23 @@ end
 % registry = tbDefaultRegistry();
 % setpref('ToolboxToolbox', 'registry', registry);
 
-% % system command used to check whether the Internet is reachable
-% if ispc()
-%     checkInternetCommand = 'ping -n 1 www.google.com';
-% else
-%     checkInternetCommand = 'ping -c 1 www.google.com';
-% end
-% setpref('ToolboxToolbox', 'checkInternetCommand', checkInternetCommand);
+% system command used to check whether the Internet is reachable
+%   this helps avoid long timeouts, when Internet isn't reachable
+%   many commands would work fine
+%   some suggestions:
+%
+% good default for Linux and OS X
+% checkInternetCommand = 'ping -c 1 www.google.com';
+%
+% good default for Windows
+% checkInternetCommand = 'ping -n 1 www.google.com';
+%
+% alternatives in case ping is blocked by firewall, etc.
+% checkInternetCommand = 'curl www.google.com';
+% checkInternetCommand = 'wget www.google.com';
+%
+% no-op to assume Internet is always reachable
+%checkInternetCommand = 'echo';
+%
+%setpref('ToolboxToolbox', 'checkInternetCommand', checkInternetCommand);
 


### PR DESCRIPTION
Would close #16 .

Clear existing ToolboxToolbox preferences in `sampleStartup.m`, to make startup more predictable.

Also, a few additional comments in `sampleStartup.m`.