### PR TITLE
preserve input order when resolving included configs

### DIFF
--- a/strategies/TbIncludeStrategy.m
+++ b/strategies/TbIncludeStrategy.m
@@ -42,7 +42,7 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                 return;
             end
             
-            % keep track of original config order
+            % extra bookkeeping field to track original config order
             inputOrder = num2cell(1:numel(config));
             [config.order] = deal(inputOrder{:});
             
@@ -90,9 +90,12 @@ classdef TbIncludeStrategy < TbToolboxStrategy
             % put results in same order as inputs
             [~, resolvedOrder] = sort([resolved.order]);
             resolved = resolved(resolvedOrder);
-            
             [~, includesOrder] = sort([includes.order]);
             includes = includes(includesOrder);
+            
+            % remove extra bookkeeping field
+            resolved = rmfield(resolved, 'order');
+            includes = rmfield(includes, 'order');
         end
         
         % Separate "include" records from resolved records

--- a/strategies/TbIncludeStrategy.m
+++ b/strategies/TbIncludeStrategy.m
@@ -42,6 +42,10 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                 return;
             end
             
+            % keep track of original config order
+            inputOrder = num2cell(1:numel(config));
+            [config.order] = deal(inputOrder{:});
+            
             [includes, resolved] = TbIncludeStrategy.separateIncludes(config);
             
             ii = 1;
@@ -64,6 +68,9 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                         continue;
                     end
                     
+                    % keep track of original config order
+                    [newConfig.order] = deal(record.order);
+                    
                     [newIncludes, newResolved] = TbIncludeStrategy.separateIncludes(newConfig);
                     includes = TbIncludeStrategy.appendMissingConfig(includes, newIncludes);
                     resolved = TbIncludeStrategy.appendMissingConfig(resolved, newResolved);
@@ -79,6 +86,13 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                     end
                 end
             end
+            
+            % put results in same order as inputs
+            [~, resolvedOrder] = sort([resolved.order]);
+            resolved = resolved(resolvedOrder);
+            
+            [~, includesOrder] = sort([includes.order]);
+            includes = includes(includesOrder);
         end
         
         % Separate "include" records from resolved records

--- a/test/fixture/registry/different.json
+++ b/test/fixture/registry/different.json
@@ -1,0 +1,13 @@
+[
+	{
+		"flavor": "",
+		"hook": "",
+		"name": "different",
+		"pathPlacement": "append",
+		"subfolder": "",
+		"toolboxRoot": "",
+		"type": "git",
+		"update": "",
+		"url": ""
+	}
+]


### PR DESCRIPTION
Would close #19 .

When resolving "include" configurations, keep track of original record order, and sort by this order when done resolving.  This causes included configurations to be inserted into the over all config, rather than appended at the end.