### PR TITLE
verbose output about skipping internet check

### DIFF
--- a/api/tbAddToolbox.m
+++ b/api/tbAddToolbox.m
@@ -7,48 +7,24 @@ function results = tbAddToolbox(varargin)
 %
 % results = tbAddToolbox( ... name, value) creates a new toolbox record
 % based on the given name-value pairs and adds it to the toolbox
-% configuration.  See tbToolboxRecord for recognized names.
+% configuration.  See tbToolboxRecord() for recognized names.
+%
+% You can also specify additional name-value pairs to specify
+% how toolboxes should be deployed.  See tbDeployToolboxes() which also
+% shares parameters with this function.
 %
 % If a toolbox with the same 'name" already exists in the configuration, it
 % will be replaced with the new one.
 %
-% tbAddToolbox( ... 'configPath', configPath) specify where to look for the
-% toolbox config file.  The default location is getpref('ToolboxToolbox',
-% 'toolboxRoot') or 'toolbox_config.json' in the userpath() folder.
-%
-% tbReadConfig( ... 'toolboxRoot', toolboxRoot) specify where to fetch
-% toolboxes.  The default location is
-% getpref('ToolboxToolbox', 'toolboxRoot'), or 'toolboxes' in the
-% userpath() folder.
-%
-% As an optimization for shares systems, toolboxes may be pre-deployed
-% (probably by an admin) to a common toolbox root folder.  Toolboxes found
-% here will be updated, instead adding new ones to the given toolboxRoot.
-%
-% tbFetchToolboxes( ... 'toolboxCommonRoot', toolboxCommonRoot) specify
-% where to look for shared toolboxes.  The default location is
-% getpref('ToolboxToolbox', 'toolboxCommonRoot'), or '/srv/toolboxes'.
-%
 % 2016 benjamin.heasly@gmail.com
-
-parser = inputParser();
-parser.KeepUnmatched = true;
-parser.addParameter('configPath', tbGetPref('configPath', fullfile(tbUserFolder(), 'toolbox_config.json')), @ischar);
-parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
-parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
-parser.parse(varargin{:});
-configPath = tbHomePathToAbsolute(parser.Results.configPath);
-toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
-toolboxCommonRoot = tbHomePathToAbsolute(parser.Results.toolboxCommonRoot);
 
 %% Make a new toolbox record.
 newRecord = tbToolboxRecord(varargin{:});
 
 %% Deploy just the new toolbox.
 results = tbDeployToolboxes( ...
+    varargin{:}, ...
     'config', newRecord, ...
-    'toolboxRoot', toolboxRoot, ...
-    'toolboxCommonRoot', toolboxCommonRoot, ...
     'reset', 'as-is');
 
 if 0 ~= results.status
@@ -57,7 +33,7 @@ if 0 ~= results.status
 end
 
 %% Add new toolbox to the existing config.
-config = tbReadConfig('configPath', configPath);
+config = tbReadConfig(varargin{:});
 if isempty(config) || ~isstruct(config) || ~isfield(config, 'name')
     config = newRecord;
 else
@@ -71,5 +47,5 @@ else
 end
 
 %% Write back the new config. after success.
-tbWriteConfig(config, 'configPath', configPath);
+tbWriteConfig(config, varargin{:});
 

--- a/api/tbAddToolboxPath.m
+++ b/api/tbAddToolboxPath.m
@@ -17,6 +17,7 @@ function toolboxPath = tbAddToolboxPath(varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addParameter('toolboxPath', pwd(), @ischar);
 parser.addParameter('pathPlacement', 'append', @ischar);
 parser.parse(varargin{:});

--- a/api/tbCheckInternet.m
+++ b/api/tbCheckInternet.m
@@ -24,7 +24,7 @@ function [isOnline, result] = tbCheckInternet(varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
-parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', 'ping -c 1 www.google.com'), @ischar);
+parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
 parser.addParameter('asAssertion', false, @islogical);
 parser.addParameter('checkInternet', true, @islogical);
 parser.parse(varargin{:});

--- a/api/tbCheckInternet.m
+++ b/api/tbCheckInternet.m
@@ -26,9 +26,19 @@ function [isOnline, result] = tbCheckInternet(varargin)
 parser = inputParser();
 parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', 'ping -c 1 www.google.com'), @ischar);
 parser.addParameter('asAssertion', false, @islogical);
+parser.addParameter('checkInternet', true, @islogical);
 parser.parse(varargin{:});
 checkInternetCommand = parser.Results.checkInternetCommand;
 asAssertion = parser.Results.asAssertion;
+checkInternet = parser.Results.checkInternet;
+
+% caller wants to skip the check?
+if ~checkInternet || isempty(checkInternetCommand)
+    fprintf('Skipping internet check.\n');
+    isOnline = true;
+    result = 'skipping internet check';
+    return;
+end
 
 % are we online?
 [status, result, fullCommand] = tbSystem(checkInternetCommand, 'echo', false);
@@ -39,6 +49,11 @@ if ~isOnline
     fprintf('Could not reach the internet.\n');
     fprintf('  command: %s\n', fullCommand);
     fprintf('  message: %s\n', result);
+    fprintf('You can skip this internet check if you want.  Either:\n');
+    fprintf(' - choose an empty ''checkInternetCommand'' in your startup.m, and re-run startup\n');
+    fprintf(' - call functions with the ''checkInternetCommand'' parameter set to empty.  For example:\n');
+    fprintf('     tbUse( ... ''checkInternetCommand'', '''')\n');
+    fprintf('     tbDeployToolboxes( ... ''checkInternetCommand'', '''')\n');
 end
 
 % if not, do we throw an error?

--- a/api/tbCheckInternet.m
+++ b/api/tbCheckInternet.m
@@ -12,8 +12,8 @@ function [isOnline, result] = tbCheckInternet(varargin)
 %
 % tbCheckInternet( ... 'checkInternetCommand', checkInternetCommand)
 % specify the command to pass to system() which will check for Internet
-% connectivity.  The default command is getpref('ToolboxToolbox',
-% 'checkInternetCommand'), or 'ping -c 1 www.google.com'.
+% connectivity.  The default command is the empty '', which means to skip
+% the check and assume connectivity.
 %
 % tbCheckInternet( ... 'asAssertion', asAssertion) specify whether to treat
 % the call to tbCheckInternet() as an assertion.  If asAssertion is true
@@ -24,16 +24,15 @@ function [isOnline, result] = tbCheckInternet(varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
 parser.addParameter('asAssertion', false, @islogical);
-parser.addParameter('checkInternet', true, @islogical);
 parser.parse(varargin{:});
 checkInternetCommand = parser.Results.checkInternetCommand;
 asAssertion = parser.Results.asAssertion;
-checkInternet = parser.Results.checkInternet;
 
 % caller wants to skip the check?
-if ~checkInternet || isempty(checkInternetCommand)
+if isempty(checkInternetCommand)
     fprintf('Skipping internet check.\n');
     isOnline = true;
     result = 'skipping internet check';

--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -71,6 +71,7 @@ function [resolved, included] = tbDeployToolboxes(varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
 parser.addParameter('configPath', tbGetPref('configPath', fullfile(tbUserFolder(), 'toolbox_config.json')), @ischar);
 parser.addParameter('config', [], @(c) isempty(c) || isstruct(c));
 parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
@@ -85,6 +86,7 @@ parser.addParameter('registered', {}, @iscellstr);
 parser.addParameter('runLocalHooks', true, @islogical);
 parser.addParameter('addToPath', true, @islogical);
 parser.parse(varargin{:});
+checkInternetCommand = parser.Results.checkInternetCommand;
 configPath = parser.Results.configPath;
 config = parser.Results.config;
 toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
@@ -102,7 +104,8 @@ addToPath = parser.Results.addToPath;
 
 %% Choose explicit config, or load from file.
 if isempty(config) || ~isstruct(config) || ~isfield(config, 'name')
-    config = tbReadConfig('configPath', configPath);
+    config = tbReadConfig('configPath', configPath, ...
+        'checkInternetCommand', checkInternetCommand);
 end
 
 

--- a/api/tbFetchRegistry.m
+++ b/api/tbFetchRegistry.m
@@ -27,12 +27,11 @@ function results = tbFetchRegistry(varargin)
 
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addParameter('registry', tbGetPref('registry', tbDefaultRegistry()), @(c) isempty(c) || isstruct(c));
-parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
 parser.addParameter('doUpdate', true, @islogical);
 parser.parse(varargin{:});
 registry = parser.Results.registry;
-toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
 doUpdate = parser.Results.doUpdate;
 
 %% Force no update?
@@ -41,5 +40,5 @@ if ~doUpdate
 end
 
 %% Obtain or update just like a toolbox.
-results = tbFetchToolboxes(registry, 'toolboxRoot', toolboxRoot);
+results = tbFetchToolboxes(registry, varargin{:});
 

--- a/api/tbFetchToolboxes.m
+++ b/api/tbFetchToolboxes.m
@@ -25,6 +25,7 @@ function results = tbFetchToolboxes(config, varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addRequired('config', @isstruct);
 parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
 parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
@@ -51,7 +52,7 @@ for tt = 1:nToolboxes
     end
     
     % what kind of toolbox is this?
-    strategy = tbChooseStrategy(record);
+    strategy = tbChooseStrategy(record, varargin{:});
     if isempty(strategy)
         results(tt).status = -1;
         results(tt).command = 'tbChooseStrategy';

--- a/api/tbGetPref.m
+++ b/api/tbGetPref.m
@@ -12,6 +12,7 @@ function value = tbGetPref(preferenceName, defaultValue)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addRequired('preferenceName', @ischar);
 parser.addRequired('defaultValue');
 parser.parse(preferenceName, defaultValue);

--- a/api/tbHomePathToAbsolute.m
+++ b/api/tbHomePathToAbsolute.m
@@ -8,6 +8,7 @@ function absolutePath = tbHomePathToAbsolute(homePath)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addRequired('homePath', @ischar);
 parser.parse(homePath);
 homePath = parser.Results.homePath;

--- a/api/tbReadConfig.m
+++ b/api/tbReadConfig.m
@@ -16,11 +16,11 @@ function [config, configPath] = tbReadConfig(varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
+parser.PartialMatching = false;
 parser.addParameter('configPath', tbGetPref('configPath', fullfile(tbUserFolder(), 'toolbox_config.json')), @ischar);
-parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
 parser.parse(varargin{:});
 configPath = parser.Results.configPath;
-checkInternetCommand = parser.Results.checkInternetCommand;
 
 config = [];
 
@@ -38,8 +38,7 @@ if ~isempty(strfind(lower(configPath), 'http://')) ...
     configPath = fullfile(tempFolder, [resourceBase, resourceExt]);
     
     try
-        tbCheckInternet('asAssertion', true, ...
-            'checkInternetCommand', checkInternetCommand);
+        tbCheckInternet(varargin{:}, 'asAssertion', true);
         configPath = websave(configPath, configUrl);
     catch
         configPath = '';

--- a/api/tbReadConfig.m
+++ b/api/tbReadConfig.m
@@ -17,8 +17,10 @@ function [config, configPath] = tbReadConfig(varargin)
 
 parser = inputParser();
 parser.addParameter('configPath', tbGetPref('configPath', fullfile(tbUserFolder(), 'toolbox_config.json')), @ischar);
+parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
 parser.parse(varargin{:});
 configPath = parser.Results.configPath;
+checkInternetCommand = parser.Results.checkInternetCommand;
 
 config = [];
 
@@ -36,7 +38,8 @@ if ~isempty(strfind(lower(configPath), 'http://')) ...
     configPath = fullfile(tempFolder, [resourceBase, resourceExt]);
     
     try
-        tbCheckInternet('asAssertion', true);
+        tbCheckInternet('asAssertion', true, ...
+            'checkInternetCommand', checkInternetCommand);
         configPath = websave(configPath, configUrl);
     catch
         configPath = '';

--- a/api/tbResetMatlabPath.m
+++ b/api/tbResetMatlabPath.m
@@ -1,9 +1,9 @@
-function [newPath, oldPath] = tbResetMatlabPath(flavor, varargin)
+function [newPath, oldPath] = tbResetMatlabPath(reset, varargin)
 % Set the Matlab path to a consistent state.
 %
-% [newPath, oldPath] = tbResetMatlabPath(flavor) sets the Matlab path to
-% a consistent state, as specified by the given flavor.  The flavor must be
-% one of the following:
+% [newPath, oldPath] = tbResetMatlabPath(reset) sets the Matlab path to
+% a consistent state, as specified by the given reset string.  The value of
+% the reset string must be one of the following:
 %   - 'full' -- Include the userpath(), all installed Matlab toolboxes,
 %   the ToolboxToolbox itself, and no other folders.  This is the default.
 %   - 'no-matlab' -- Like 'full', but does not include any installed
@@ -16,13 +16,13 @@ function [newPath, oldPath] = tbResetMatlabPath(flavor, varargin)
 %   useful when specifying specific folders to 'add' or 'remove', below.
 %
 % tbResetMatlabPath( ... 'remove', remove) specifies folders to remove from
-% to the Matlab path, after setting the path to the given flavor.  Valid
+% to the Matlab path, after setting the path to the given reset.  Valid
 % values for remove are:
 %   - 'self' -- Remove the ToolboxToolbox itself from the path.
 %   - 'matlab' -- Remove all installed Matlab toolboxes from the path.
 %
 % tbResetMatlabPath( ... 'add', add) specifies folders to add to the Matlab
-% path, after setting the path to the given flavor.  Valid values for add
+% path, after setting the path to the given reset.  Valid values for add
 % are:
 %   - 'self' -- Append the ToolboxToolbox itself to the path.
 %   - 'matlab' -- Append all installed Matlab toolboxes to the path.
@@ -31,20 +31,21 @@ function [newPath, oldPath] = tbResetMatlabPath(flavor, varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
-parser.addRequired('flavor', @(f) any(strcmp(f, {'full', 'no-matlab', 'no-self', 'bare', 'as-is'})));
+parser.KeepUnmatched = true;
+parser.addRequired('reset', @(f) any(strcmp(f, {'full', 'no-matlab', 'no-self', 'bare', 'as-is'})));
 parser.addParameter('add', '', @ischar);
 parser.addParameter('remove', '', @ischar);
-parser.parse(flavor, varargin{:});
-flavor = parser.Results.flavor;
+parser.parse(reset, varargin{:});
+reset = parser.Results.reset;
 add = parser.Results.add;
 remove = parser.Results.remove;
 
 oldPath = path();
 
 % convert arguments to some to-do items.
-factoryReset = ~strcmp(flavor, 'as-is');
-removeSelf = strcmp(flavor, 'no-self') || strcmp(flavor, 'bare') || strcmp(remove, 'self');
-removeMatlab = strcmp(flavor, 'no-matlab') || strcmp(flavor, 'bare') || strcmp(remove, 'matlab');
+factoryReset = ~strcmp(reset, 'as-is');
+removeSelf = strcmp(reset, 'no-self') || strcmp(reset, 'bare') || strcmp(remove, 'self');
+removeMatlab = strcmp(reset, 'no-matlab') || strcmp(reset, 'bare') || strcmp(remove, 'matlab');
 addMatlab = strcmp(add, 'matlab');
 
 

--- a/api/tbSearchRegistry.m
+++ b/api/tbSearchRegistry.m
@@ -18,6 +18,7 @@ function configPath = tbSearchRegistry(name, varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addRequired('name', @ischar);
 parser.addParameter('registry', tbGetPref('registry', tbDefaultRegistry()), @(c) isempty(c) || isstruct(c));
 parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
@@ -27,7 +28,7 @@ registry = parser.Results.registry;
 toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
 
 %% Locate the folder that contains the registry.
-strategy = tbChooseStrategy(registry);
+strategy = tbChooseStrategy(registry, varargin{:});
 registryPath = strategy.toolboxPath(toolboxRoot, registry, 'withSubfolder', true);
 
 %% Check for the named configuration.

--- a/api/tbSystem.m
+++ b/api/tbSystem.m
@@ -18,6 +18,7 @@ function [status, result, fullCommand] = tbSystem(command, varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addRequired('command', @ischar);
 parser.addParameter('keep', {}, @iscellstr);
 parser.addParameter('echo', true, @islogical);

--- a/api/tbToolboxPath.m
+++ b/api/tbToolboxPath.m
@@ -16,6 +16,7 @@ function [toolboxPath, subfolder] = tbToolboxPath(toolboxRoot, record, varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addRequired('toolboxRoot', @ischar);
 parser.addRequired('record', @isstruct);
 parser.addParameter('withSubfolder', false, @islogical);

--- a/api/tbUse.m
+++ b/api/tbUse.m
@@ -12,71 +12,17 @@ function results = tbUse(registered, varargin)
 % results = tbUse({'foo', 'bar', ...}) fetches toolboxes named
 % 'foo', 'bar', etc. from ToolboxHub and adds them to the matlab path.
 %
-% tbUse(... 'toolboxRoot', toolboxRoot) specifies the
-% toolboxRoot folder to set the path for.  The default location is
-% getpref('ToolboxToolbox', 'toolboxRoot'), or 'toolboxes' in the
-% userpath() folder.
-%
-% tbUse(... 'reset', reset) specifies how to reset the Matlab path before
-% processing the given configuration.  The default is 'as-is', don't reset
-% the path at all.  See tbResetMatlabPath().
-%
-% tbUse( ... 'remove', remove) specifies folders to remove from
-% to the Matlab path, after setting the path to the given flavor.  See
-% tbResetMatlabPath(). 
-%
-% tbUse( ... 'add', add) specifies folders to add to the Matlab
-% path, after setting the path to the given flavor.  See
-% tbResetMatlabPath().
-%
-% tbUse( ... 'registry', registry) specify an explicit toolbox
-% record which indicates where and how to access a registry of shared
-% toolbox configurations.  The default is getpref('ToolboxToolbox',
-% 'registry'), or the public registry at Toolbox Hub.
-%
-% tbUse(... 'localHookFolder', localHookFolder) specifies the
-% path to the folder that contains local hook scripts.  The default
-% location is getpref('ToolboxToolbox', 'localHookFolder'), or
-% 'localToolboxHooks' in the userpath() folder.
-%
-% tbUse(... 'runLocalHooks', runLocalHooks) specifies whether
-% to run the local hooks deployed toolboxes (true), or not (false).  The
-% default is true, run the local hooks.
-%
-% tbUse(... 'addToPath', addToPath) specifies whether
-% to add deployed toolboxes (true) to the Matlab path, or not (false).  The
-% default is true, add toolboxes to the path.
-%
-% tbUse( ... 'toolboxCommonRoot', toolboxCommonRoot) specify
-% where to look for shared toolboxes. The default location is
-% getpref('ToolboxToolbox', 'toolboxCommonRoot'), or '/srv/toolboxes'.
+% tbUse(... 'name', value) specify additional name-value pairs to specify
+% how toolboxes should be deployed.  See tbDeployToolboxes() which shares
+% parameters with this function.
 %
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
 parser.addRequired('registered', @(r) ischar(r) || iscellstr(r));
-parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
-parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
-parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
-parser.addParameter('reset', 'as-is', @ischar);
-parser.addParameter('add', '', @ischar);
-parser.addParameter('remove', '', @ischar);
-parser.addParameter('localHookFolder', tbGetPref('localHookFolder', fullfile(tbUserFolder(), 'localHookFolder')), @ischar);
-parser.addParameter('registry', tbGetPref('registry', tbDefaultRegistry()), @(c) isempty(c) || isstruct(c));
-parser.addParameter('runLocalHooks', true, @islogical);
-parser.addParameter('addToPath', true, @islogical);
 parser.parse(registered, varargin{:});
 registered = parser.Results.registered;
-checkInternetCommand = parser.Results.checkInternetCommand;
-toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
-toolboxCommonRoot = tbHomePathToAbsolute(parser.Results.toolboxCommonRoot);
-reset = parser.Results.reset;
-add = parser.Results.add;
-remove = parser.Results.remove;
-localHookFolder = parser.Results.localHookFolder;
-registry = parser.Results.registry;
-runLocalHooks = parser.Results.runLocalHooks;
-addToPath = parser.Results.addToPath;
 
 % convert convenient string form to general list form
 if ischar(registered)
@@ -84,14 +30,5 @@ if ischar(registered)
 end
 
 results = tbDeployToolboxes( ...
-    'registered', registered, ...
-    'checkInternetCommand', checkInternetCommand, ...
-    'toolboxRoot', toolboxRoot, ...
-    'toolboxCommonRoot', toolboxCommonRoot, ...
-    'reset', reset, ...
-    'add', add, ...
-    'remove', remove, ...
-    'localHookFolder', localHookFolder, ...
-    'registry', registry, ...
-    'runLocalHooks', runLocalHooks, ...
-    'addToPath', addToPath);
+    varargin{:}, ...
+    'registered', registered);

--- a/api/tbUse.m
+++ b/api/tbUse.m
@@ -55,6 +55,7 @@ function results = tbUse(registered, varargin)
 
 parser = inputParser();
 parser.addRequired('registered', @(r) ischar(r) || iscellstr(r));
+parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
 parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
 parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
 parser.addParameter('reset', 'as-is', @ischar);
@@ -66,6 +67,7 @@ parser.addParameter('runLocalHooks', true, @islogical);
 parser.addParameter('addToPath', true, @islogical);
 parser.parse(registered, varargin{:});
 registered = parser.Results.registered;
+checkInternetCommand = parser.Results.checkInternetCommand;
 toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
 toolboxCommonRoot = tbHomePathToAbsolute(parser.Results.toolboxCommonRoot);
 reset = parser.Results.reset;
@@ -83,6 +85,7 @@ end
 
 results = tbDeployToolboxes( ...
     'registered', registered, ...
+    'checkInternetCommand', checkInternetCommand, ...
     'toolboxRoot', toolboxRoot, ...
     'toolboxCommonRoot', toolboxCommonRoot, ...
     'reset', reset, ...

--- a/api/tbWriteConfig.m
+++ b/api/tbWriteConfig.m
@@ -16,6 +16,8 @@ function configPath = tbWriteConfig(config, varargin)
 % 2016 benjamin.heasly@gmail.com
 
 parser = inputParser();
+parser.KeepUnmatched = true;
+parser.PartialMatching = false;
 parser.addRequired('config', @isstruct);
 parser.addParameter('configPath', tbGetPref('configPath', fullfile(tbUserFolder(), 'toolbox_config.json')), @ischar);
 parser.parse(config, varargin{:});

--- a/sampleStartup.m
+++ b/sampleStartup.m
@@ -93,7 +93,7 @@ rmpref('ToolboxToolbox');
 % checkInternetCommand = 'wget www.google.com';
 %
 % no-op to assume Internet is always reachable
-%checkInternetCommand = 'echo';
+% checkInternetCommand = '';
 %
 %setpref('ToolboxToolbox', 'checkInternetCommand', checkInternetCommand);
 

--- a/strategies/TbDockerStrategy.m
+++ b/strategies/TbDockerStrategy.m
@@ -24,7 +24,7 @@ classdef TbDockerStrategy < TbToolboxStrategy
                     command = ['docker pull ' record.url ':' record.flavor];
                 end
                 
-                tbCheckInternet('asAssertion', true);
+                obj.checkInternet('asAssertion', true);
                 [status, result] = tbSystem(command);
                 if 0 ~= status
                     error('Docker pull failed: %s', result);

--- a/strategies/TbGitStrategy.m
+++ b/strategies/TbGitStrategy.m
@@ -13,20 +13,6 @@ classdef TbGitStrategy < TbToolboxStrategy
             assert(gitWorks, 'TbGitStrategy:gitNotWorking', ...
                 'Git seems not to be working.  Got error: <%s>.', result);
         end
-        
-        function [status, result, fullCommand] = systemInFolder(command, folder)
-            originalFolder = pwd();
-            try
-                tbCheckInternet('asAssertion', true);
-                cd(folder);
-                [status, result, fullCommand] = tbSystem(command);
-            catch err
-                status = -1;
-                result = err.message;
-                fullCommand = command;
-            end
-            cd(originalFolder);
-        end
     end
     
     methods
@@ -45,7 +31,7 @@ classdef TbGitStrategy < TbToolboxStrategy
             command = sprintf('git clone "%s" "%s"', ...
                 record.url, ...
                 toolboxPath);
-            [status, message, fullCommand] = TbGitStrategy.systemInFolder(command, toolboxRoot);
+            [status, message, fullCommand] = obj.systemInFolder(command, toolboxRoot);
             if 0 ~= status
                 return;
             end
@@ -53,7 +39,7 @@ classdef TbGitStrategy < TbToolboxStrategy
             if ~isempty(record.flavor)
                 % git checkout sampleBranch
                 command = sprintf('git checkout %s', record.flavor);
-                [status, message, fullCommand] = TbGitStrategy.systemInFolder(command, toolboxPath);
+                [status, message, fullCommand] = obj.systemInFolder(command, toolboxPath);
                 if 0 ~= status
                     return;
                 end
@@ -71,7 +57,22 @@ classdef TbGitStrategy < TbToolboxStrategy
             else
                 command = sprintf('git pull origin %s', record.flavor);
             end
-            [status, message, fullCommand] = TbGitStrategy.systemInFolder(command, toolboxPath);
+            [status, message, fullCommand] = obj.systemInFolder(command, toolboxPath);
         end
+        
+        function [status, result, fullCommand] = systemInFolder(obj, command, folder)
+            originalFolder = pwd();
+            try
+                obj.checkInternet('asAssertion', true);
+                cd(folder);
+                [status, result, fullCommand] = tbSystem(command);
+            catch err
+                status = -1;
+                result = err.message;
+                fullCommand = command;
+            end
+            cd(originalFolder);
+        end
+        
     end
 end

--- a/strategies/TbIncludeStrategy.m
+++ b/strategies/TbIncludeStrategy.m
@@ -35,7 +35,7 @@ classdef TbIncludeStrategy < TbToolboxStrategy
     
     methods (Static)
         % Iterate the given config, resolve and append new records as they come.
-        function [resolved, includes] = resolveIncludedConfigs(config, registry)
+        function [resolved, includes] = resolveIncludedConfigs(config, registry, varargin)
             if isempty(config)
                 resolved = [];
                 includes = [];
@@ -55,7 +55,9 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                 
                 if isempty(record.url)
                     % look up config location by name in registry
-                    url = tbSearchRegistry(record.name, 'registry', registry);
+                    url = tbSearchRegistry(record.name, ...
+                        varargin{:}, ...
+                        'registry', registry);
                 else
                     % explicit location of config file
                     url = record.url;
@@ -63,7 +65,7 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                 
                 if ~isempty(url)
                     % append the included config so it can be resolved
-                    newConfig = tbReadConfig('configPath', url);
+                    newConfig = tbReadConfig(varargin{:}, 'configPath', url);
                     if isempty(newConfig) || ~isstruct(newConfig) || ~isfield(newConfig, 'name')
                         continue;
                     end
@@ -81,7 +83,7 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                     if ~isempty(updateIndex)
                         updated = newIncludes(updateIndex);
                         if ~isequal(record, updated)
-                            includes = [includes updated];
+                            includes = [includes updated];%#ok
                         end
                     end
                 end

--- a/strategies/TbToolboxStrategy.m
+++ b/strategies/TbToolboxStrategy.m
@@ -13,6 +13,10 @@ classdef TbToolboxStrategy < handle
     %
     % 2016 benjamin.heasly@gmail.com
     
+    properties
+        checkInternetCommand = '';
+    end
+    
     methods (Abstract)
         [command, status, message] = obtain(obj, record, toolboxRoot, toolboxPath);
         [command, status, message] = update(obj, record, toolboxRoot, toolboxPath);
@@ -33,6 +37,12 @@ classdef TbToolboxStrategy < handle
             tbAddToolboxPath( ...
                 'toolboxPath', toolboxPath, ...
                 'pathPlacement', record.pathPlacement);
+        end
+        
+        function [isOnline, result] = checkInternet(obj, varargin)
+            [isOnline, result] = tbCheckInternet( ...
+                'checkInternetCommand', obj.checkInternetCommand, ...
+                varargin{:});
         end
     end
 end

--- a/strategies/TbWebGetStrategy.m
+++ b/strategies/TbWebGetStrategy.m
@@ -18,7 +18,7 @@ classdef TbWebGetStrategy < TbToolboxStrategy
                 [~, resourceBase, resourceExt] = fileparts(record.url);
                 fileName = fullfile(toolboxPath, [resourceBase, resourceExt]);
                
-                tbCheckInternet('asAssertion', true);
+                obj.checkInternet('asAssertion', true);
                 fileName = websave(fileName, record.url);
                 
                 if strcmp(resourceExt, '.zip')

--- a/strategies/tbChooseStrategy.m
+++ b/strategies/tbChooseStrategy.m
@@ -1,4 +1,4 @@
-function strategy = tbChooseStrategy(record)
+function strategy = tbChooseStrategy(record, varargin)
 % Choose a TbToolboxStrategy appropriate for the given toolbox record.
 %
 % strategy = tbChooseStrategy(record) chooses an implementaton of
@@ -15,8 +15,10 @@ function strategy = tbChooseStrategy(record)
 
 parser = inputParser();
 parser.addRequired('record', @isstruct);
+parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
 parser.parse(record);
 record = parser.Results.record;
+checkInternetCommand = parser.Results.checkInternetCommand;
 
 strategy = [];
 
@@ -27,6 +29,7 @@ end
 %% Default is "include"
 if isempty(record.type)
     strategy = TbIncludeStrategy();
+    strategy.checkInternetCommand = checkInternetCommand;
     return;
 end
 
@@ -34,21 +37,27 @@ end
 switch record.type
     case 'git'
         strategy = TbGitStrategy();
+        strategy.checkInternetCommand = checkInternetCommand;
         return;
     case 'webget'
         strategy = TbWebGetStrategy();
+        strategy.checkInternetCommand = checkInternetCommand;
         return;
     case 'local'
         strategy = TbLocalStrategy();
+        strategy.checkInternetCommand = checkInternetCommand;
         return;
     case 'installed'
         strategy = TbInstalledStrategy();
+        strategy.checkInternetCommand = checkInternetCommand;
         return;
     case 'docker'
         strategy = TbDockerStrategy();
+        strategy.checkInternetCommand = checkInternetCommand;
         return;
     case 'include'
         strategy = TbIncludeStrategy();
+        strategy.checkInternetCommand = checkInternetCommand;
         return;
 end
 
@@ -56,5 +65,6 @@ end
 if 2 == exist(record.type, 'class')
     constructor = str2func(record.type);
     strategy = feval(constructor);
+    strategy.checkInternetCommand = checkInternetCommand;
     return;
 end


### PR DESCRIPTION
When `tbCheckInternet()` can't reach the internet, print advice about skipping further checks.

Default to empty `checkInternetCommand`, to be treated as "skip the internet checks and assume connectivity".

Parameters like `checkInternetCommand` can pass from top level functions, like `tbUse()` to lower level functions, like `tbCheckInternet`.

Add `checkInternetCommand` to strategy superclass.