### PR TITLE
Locate toolboxes

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -180,7 +180,10 @@ if addToPath
         record = resolved(tt);
         
         % add shared toolbox to path?
-        toolboxPath = commonOrNormalPath(toolboxCommonRoot, toolboxRoot, record, true);
+        toolboxPath = tbLocateToolbox(record, ...
+            'toolboxCommonRoot', toolboxCommonRoot, ...
+            'toolboxRoot', toolboxRoot, ...
+            'withSubfolder', true);
         if 7 == exist(toolboxPath, 'dir')
             fprintf('Adding "%s" to path at "%s".\n', record.name, toolboxPath);
             record.strategy.addToPath(record, toolboxPath);
@@ -213,7 +216,10 @@ end
 nToolboxes = numel(resolved);
 for tt = 1:nToolboxes
     record = resolved(tt);
-    [~, toolboxName] = commonOrNormalPath(toolboxCommonRoot, toolboxRoot, record, false);
+    [~, toolboxName] = tbLocateToolbox(record, ...
+        'toolboxCommonRoot', toolboxCommonRoot, ...
+        'toolboxRoot', toolboxRoot, ...
+        'withSubfolder', false);
     if ~isempty(record.hook) && 2 ~= exist(record.hook, 'file')
         fprintf('Running hook for "%s": "%s".\n', toolboxName, record.hook);
         [resolved(tt).status, resolved(tt).message] = evalIsolated(record.hook);
@@ -239,25 +245,12 @@ if ~isempty(included)
 end
 
 
-%% Choose a shared or normal path for the toolbox.
-function [toolboxPath, displayName] = commonOrNormalPath(toolboxCommonRoot, toolboxRoot, record, withSubfolder)
-strategy = tbChooseStrategy(record);
-[toolboxPath, displayName] = strategy.toolboxPath(toolboxCommonRoot, record, 'withSubfolder', withSubfolder);
-if 7 == exist(toolboxPath, 'dir')
-    return;
-end
-
-[toolboxPath, displayName] = strategy.toolboxPath(toolboxRoot, record, 'withSubfolder', withSubfolder);
-if 7 == exist(toolboxPath, 'dir')
-    return;
-end
-
-toolboxPath = '';
-
-
 %% Invoke a local hook, create if necessary.
 function record = invokeLocalHook(toolboxCommonRoot, toolboxRoot, localHookFolder, record)
-[toolboxPath, hookName] = commonOrNormalPath(toolboxCommonRoot, toolboxRoot, record, false);
+[toolboxPath, hookName] = tbLocateToolbox(record, ...
+    'toolboxCommonRoot', toolboxCommonRoot, ...
+    'toolboxRoot', toolboxRoot, ...
+    'withSubfolder', false);
 fprintf('Checking for "%s" local hook.\n', hookName);
 
 % create a local hook if missing and a template exists

--- a/api/tbLocateSelf.m
+++ b/api/tbLocateSelf.m
@@ -1,0 +1,10 @@
+function selfPath = tbLocateSelf()
+% Locate the folder where ToolboxToolbox is installed.
+%
+% selfPath = tbLocateSelf() retrns the path to where the ToolboxToolbox is
+% located, based on the location of this function.
+%
+% 2016 benjamin.heasly@gmail.com
+
+pathHere = fileparts(mfilename('fullpath'));
+selfPath = fileparts(pathHere);

--- a/api/tbLocateToolbox.m
+++ b/api/tbLocateToolbox.m
@@ -1,0 +1,52 @@
+function [toolboxPath, displayName] = tbLocateToolbox(toolbox, varargin)
+% Locate the folder that contains the given toolbox.
+%
+% toolboxPath = tbLocateToolbox(name) locates the toolbox with the given
+% string name and returns the path to that toolbox.  This may be a path
+% within the configured toolboxRoot, or toolboxCommonRoot.
+%
+% toolboxPath = tbLocateToolbox(record) locates the toolbox from the given
+% record struct, instead of the given string name.
+%
+% 2016 benjamin.heasly@gmail.com
+
+parser = inputParser();
+parser.KeepUnmatched = true;
+parser.PartialMatching = false;
+parser.addRequired('toolbox', @(val) ischar(val) || isstruct(val));
+parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
+parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
+parser.addParameter('withSubfolder', true, @islogical);
+parser.parse(toolbox, varargin{:});
+toolbox = parser.Results.toolbox;
+toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
+toolboxCommonRoot = tbHomePathToAbsolute(parser.Results.toolboxCommonRoot);
+withSubfolder = parser.Results.withSubfolder;
+
+% convert convenient string to general toolbox record
+if ischar(toolbox)
+    record = tbToolboxRecord(varargin{:}, 'name', toolbox);
+else
+    record = toolbox;
+end
+strategy = tbChooseStrategy(record, varargin{:});
+
+% first, look for a shared toolbox
+[toolboxPath, displayName] = strategy.toolboxPath(toolboxCommonRoot, record, ...
+    'withSubfolder', withSubfolder);
+if 7 == exist(toolboxPath, 'dir')
+    return;
+end
+
+% then look for a regular toolbox
+[toolboxPath, displayName] = strategy.toolboxPath(toolboxRoot, record, ...
+    'withSubfolder', withSubfolder);
+if 7 == exist(toolboxPath, 'dir')
+    return;
+end
+
+% din't find the toolbox
+toolboxPath = '';
+displayName = record.name;
+
+


### PR DESCRIPTION
Would close #29 

Adds `tbLocateToolbox()`

This can take a toolbox name.  It will attempt to locate the named toolbox in the configured toolboxCommonRoot or toolboxRoot.  For example:
```
>> tbLocateToolbox('RenderToolbox4')
ans =
/home/ben/toolboxes/RenderToolbox4
```

It can also take additional toolbox record fields as name-value pairs.  This is useful when the toolbox isn't normally found in the toolboxCommonRoot or toolboxRoot.  For example, with installed Matlab toolboxes:
```
>> tbLocateToolbox('images', 'type', 'installed')
ans =
/usr/local/MATLAB/R2016a/toolbox/images
```

It can also take a full toolbox record struct instead of a toolbox name.  This is used internally and replaces a subfunction of `tbDeployToolboxes`.