### PR TITLE
local hooks named Foo.m or FooLocalHook.m

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -253,18 +253,34 @@ function record = invokeLocalHook(toolboxCommonRoot, toolboxRoot, localHookFolde
     'withSubfolder', false);
 fprintf('Checking for "%s" local hook.\n', hookName);
 
+% look for Foo.m or FooLocalHook.m
+simpleHookPath = fullfile(localHookFolder, [hookName '.m']);
+simpleHookExists = 2 == exist(simpleHookPath, 'file');
+explicitHookPath = fullfile(localHookFolder, [hookName 'LocalHook.m']);
+explicitHookExists = 2 == exist(explicitHookPath, 'file');
+
 % create a local hook if missing and a template exists
-templateLocalHookPath = fullfile(toolboxPath, record.localHookTemplate);
-existingLocalHookPath = fullfile(localHookFolder, [hookName '.m']);
-if 2 ~= exist(existingLocalHookPath, 'file') && 2 == exist(templateLocalHookPath, 'file');
-    fprintf('  Creating local hook from template "%s".\n', templateLocalHookPath);
-    copyfile(templateLocalHookPath, existingLocalHookPath);
+templatePath = fullfile(toolboxPath, record.localHookTemplate);
+templateExists = 2 == exist(templatePath, 'file');
+if ~simpleHookExists && ~explicitHookExists && templateExists
+    fprintf('  Creating local hook from template "%s".\n', templatePath);
+    copyfile(templatePath, explicitHookPath);
+    explicitHookExists = true;
+end
+
+% which hook exists, if any?
+if explicitHookExists
+    hookPath = explicitHookPath;
+elseif simpleHookExists
+    hookPath = simpleHookPath;
+else
+    hookPath = '';
 end
 
 % invoke the local hook if it exists
-if 2 == exist(existingLocalHookPath, 'file')
-    fprintf('  Running local hook "%s".\n', existingLocalHookPath);
-    command = ['run ' existingLocalHookPath];
+if ~isempty(hookPath);
+    fprintf('  Running local hook "%s".\n', hookPath);
+    command = ['run ' hookPath];
     [record.status, record.message] = evalIsolated(command);
     
     if 0 == record.status

--- a/test/TbLocalHookTest.m
+++ b/test/TbLocalHookTest.m
@@ -47,8 +47,32 @@ classdef TbLocalHookTest  < matlab.unittest.TestCase
     end
     
     methods (Test)
-        function testExistingGoodHook(obj)
+        function testExistingGoodHookSimpleName(obj)
             % make the "good" hook exist in the local hooks folder
+            %   with the simple name "local_toolbox.m"
+            pathHere = fileparts(mfilename('fullpath'));
+            goodHook = fullfile(pathHere, 'fixture', 'goodHook.m');
+            localHook = fullfile(obj.localHookFolder, 'local_toolbox.m');
+            mkdir(obj.localHookFolder);
+            copyfile(goodHook, localHook);
+            
+            % deplpoy should detect and run the good hook
+            record = tbToolboxRecord( ...
+                'type', 'local', ...
+                'name', 'local_toolbox', ...
+                'url', obj.localFolder);
+            results = tbDeployToolboxes( ...
+                'config', record, ...
+                'reset', 'full', ...
+                'localHookFolder', obj.localHookFolder);
+            
+            % good hook should have run without error
+            obj.assertEqual(results.status, 0);
+        end
+        
+        function testExistingGoodHookExplicitName(obj)
+            % make the "good" hook exist in the local hooks folder
+            %   with the simple name "local_toolboxLocalHook.m"
             pathHere = fileparts(mfilename('fullpath'));
             goodHook = fullfile(pathHere, 'fixture', 'goodHook.m');
             localHook = fullfile(obj.localHookFolder, 'local_toolbox.m');


### PR DESCRIPTION
Would close #43 .

Local hook for toolbox Foo may be named "FooLocalHook.m" (new default) or "Foo.m" (for compatibility).