### PR TITLE
toolbox record allows multiple subfolders

### DIFF
--- a/api/tbFetchToolboxes.m
+++ b/api/tbFetchToolboxes.m
@@ -6,8 +6,8 @@ function results = tbFetchToolboxes(config, varargin)
 %
 % results = tbFetchToolboxes(config) fetches or updates each of the
 % toolboxes named in the given config struct (see tbReadConfig).  Each
-% toolbox will be located in a subfolder of the default toolbox root
-% folder.
+% toolbox will be located in a subfolder of the configured toolboxRoot or
+% toolboxCommonRoot folder.
 %
 % tbFetchToolboxes( ... 'toolboxRoot', toolboxRoot) specify where to put
 % toolboxes.  The default location is

--- a/api/tbLocateToolbox.m
+++ b/api/tbLocateToolbox.m
@@ -16,12 +16,10 @@ parser.PartialMatching = false;
 parser.addRequired('toolbox', @(val) ischar(val) || isstruct(val));
 parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
 parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
-parser.addParameter('withSubfolder', true, @islogical);
 parser.parse(toolbox, varargin{:});
 toolbox = parser.Results.toolbox;
 toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
 toolboxCommonRoot = tbHomePathToAbsolute(parser.Results.toolboxCommonRoot);
-withSubfolder = parser.Results.withSubfolder;
 
 % convert convenient string to general toolbox record
 if ischar(toolbox)
@@ -32,15 +30,13 @@ end
 strategy = tbChooseStrategy(record, varargin{:});
 
 % first, look for a shared toolbox
-[toolboxPath, displayName] = strategy.toolboxPath(toolboxCommonRoot, record, ...
-    'withSubfolder', withSubfolder);
+[toolboxPath, displayName] = strategy.toolboxPath(toolboxCommonRoot, record);
 if 7 == exist(toolboxPath, 'dir')
     return;
 end
 
 % then look for a regular toolbox
-[toolboxPath, displayName] = strategy.toolboxPath(toolboxRoot, record, ...
-    'withSubfolder', withSubfolder);
+[toolboxPath, displayName] = strategy.toolboxPath(toolboxRoot, record);
 if 7 == exist(toolboxPath, 'dir')
     return;
 end

--- a/api/tbSearchRegistry.m
+++ b/api/tbSearchRegistry.m
@@ -29,7 +29,16 @@ toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
 
 %% Locate the folder that contains the registry.
 strategy = tbChooseStrategy(registry, varargin{:});
-registryPath = strategy.toolboxPath(toolboxRoot, registry, 'withSubfolder', true);
+registryBasePath = strategy.toolboxPath(toolboxRoot, registry);
+
+% use one registry subfolder, if any
+if ischar(registry.subfolder)
+    registryPath = fullfile(registryBasePath, registry.subfolder);
+elseif iscellstr(registry.subfolder)
+    registryPath = fullfile(registryBasePath, registry.subfolder{1});
+else
+    registryPath = registryBasePath;
+end
 
 %% Check for the named configuration.
 registryContents = dir(registryPath);

--- a/api/tbToolboxPath.m
+++ b/api/tbToolboxPath.m
@@ -1,17 +1,12 @@
-function [toolboxPath, subfolder] = tbToolboxPath(toolboxRoot, record, varargin)
+function [toolboxPath, displayName] = tbToolboxPath(toolboxRoot, record, varargin)
 % Build a consistent toolbox path based on the root and a toolbox record.
 %
 % toolboxPath = tbToolboxPath(toolboxRoot, record) builds a
 % consistently-formatted toolbox path which incorporates the given
 % toolboxRoot folder and the name and flavor of the given toolbox record.
 %
-% tbToolboxPath( ... 'withSubfolder', withSubfolder) specify whether to
-% append the given record.subfolder to the toolbox path (true) or not
-% (false).  The default is false, omit the subfolder.
-%
 % Returns an absolute path where the toolbox is located.  Also returns a
-% subfolder which is the last part of the absolute path, handy as a display
-% name for the toolbox.
+% part of the path, that would make for a handy as a display name.
 %
 % 2016 benjamin.heasly@gmail.com
 
@@ -19,27 +14,24 @@ parser = inputParser();
 parser.KeepUnmatched = true;
 parser.addRequired('toolboxRoot', @ischar);
 parser.addRequired('record', @isstruct);
-parser.addParameter('withSubfolder', false, @islogical);
 parser.parse(toolboxRoot, record, varargin{:});
 toolboxRoot = tbHomePathToAbsolute(parser.Results.toolboxRoot);
 record = parser.Results.record;
-withSubfolder = parser.Results.withSubfolder;
 
-%% Choose subfolder for the toolbox.
-% basic subfolder for toolbox with no special flavor
-subfolder = record.name;
+
+%% Choose folder name for the toolbox.
+% basic folder name for toolbox with no special flavor
+toolboxFolder = record.name;
 
 % append flavor as "name_flavor"
 %   don't use name/flavor -- don't want to nest flavors inside basic
 if ~isempty(record.flavor)
-    subfolder = [subfolder '_' record.flavor];
+    toolboxFolder = [toolboxFolder '_' record.flavor];
 end
+displayName = toolboxFolder;
 
-if withSubfolder
-    subfolder = fullfile(subfolder, record.subfolder);
-end
 
-%% Choose root folder to contain the subfolder.
+%% Choose root folder to contain the toolbox.
 if isempty(record.toolboxRoot)
     % put this toolbox with all the other toolboxes
     pathRoot = toolboxRoot;
@@ -49,4 +41,4 @@ else
 end
 
 % return a full path
-toolboxPath = fullfile(pathRoot, subfolder);
+toolboxPath = fullfile(pathRoot, toolboxFolder);

--- a/api/tbToolboxRecord.m
+++ b/api/tbToolboxRecord.m
@@ -20,8 +20,8 @@ function record = tbToolboxRecord(varargin)
 %   name of a custom TbToolboxStrategy subclass.
 %   - 'flavor' optional flavor of toolbox, for example a Git
 %   branch/tag/commit to checkout after cloning
-%   - 'subfolder' optional toolbox subfolder to add to path, instead of the
-%   whole toolbox
+%   - 'subfolder' optional toolbox subfolder or cell array of subfolders to
+%   add to path, instead of the whole toolbox
 %   - 'update' optional update control, if "never", won't attempt to update the toolbox
 %   - 'importance' optional error control, if "optional", errors with this
 %   toolbox won't cause the whole deployment to fail. 
@@ -42,7 +42,7 @@ parser.addParameter('name', '', @ischar);
 parser.addParameter('url', '', @ischar);
 parser.addParameter('type', '', @ischar);
 parser.addParameter('flavor', '', @ischar);
-parser.addParameter('subfolder', '', @ischar);
+parser.addParameter('subfolder', '', @(val) ischar(val) || iscellstr(val));
 parser.addParameter('update', '', @ischar);
 parser.addParameter('hook', '', @ischar);
 parser.addParameter('localHookTemplate', '', @ischar);


### PR DESCRIPTION
Would close #36 .

Allows toolbox records to list multiple subfolders in the `subfolder` field, so each can be added to path.