### PR TITLE
Native strategy

### DIFF
--- a/strategies/TbNativeStrategy.m
+++ b/strategies/TbNativeStrategy.m
@@ -1,0 +1,47 @@
+classdef TbNativeStrategy < TbToolboxStrategy
+    % Check for native system dependencies.
+    %
+    % TbNativeStrategy checks for native system dependencies, such as
+    % shared libraries that are installed by apt-get, homebrew, etc.
+    % TbNativeStrategy can't actually install these dependencies, but it is
+    % still useful:
+    %   - It gives a way to declare and document the depenencies as part of
+    %   the toolbox configuration struct/JSON.
+    %   - It gives a way to "fail fast" and print a useful message at
+    %   toolbox deployment time, as opposed to waiting for an obscure error
+    %   to crop up later on.
+    %
+    % The way it works, is the user must supply a special hook for the
+    % toolbox record.  This should be the name of a function in the
+    % toolbox.  This function must return 3 values:
+    %   - a status code indicating whether the native dependency was
+    %   found -- 0 -> success, non-zero -> failure
+    %   - a message indicating success or failure, such as the result
+    %   returned from system()
+    %   - on failure, useful links and/or advice to the user about how to
+    %   obtain the missing dependency -- may be empty on success
+    %
+    % 2016-2017 benjamin.heasly@gmail.com
+    
+    methods
+        function [command, status, message] = obtain(obj, record, toolboxRoot, toolboxPath)
+            % check if the native dependency is present
+            command = record.hook;
+            fprintf('Checking for native dependency "%s" using function "%s":\n', ...
+                record.name, command);
+            [status, message, advice] = eval(command);
+            
+            % try to display useful messages
+            if 0 == status
+                fprintf('  OK: "%s":\n', message);
+            else
+                fprintf('  Not found: "%s":\n\n', message);
+                fprintf('  Suggestion: "%s":\n\n', advice);
+            end
+        end
+        
+        function [command, status, message] = update(obj, record, toolboxRoot, toolboxPath)
+            [command, status, message] = obj.obtain(record, toolboxRoot, toolboxPath);
+        end
+    end
+end

--- a/strategies/tbChooseStrategy.m
+++ b/strategies/tbChooseStrategy.m
@@ -49,6 +49,8 @@ switch record.type
         strategy = TbDockerStrategy();
     case 'include'
         strategy = TbIncludeStrategy();
+    case 'native'
+        strategy = TbNativeStrategy();
 end
 
 %% Use type as class name.

--- a/test/TbDockerTest.m
+++ b/test/TbDockerTest.m
@@ -17,7 +17,7 @@ classdef TbDockerTest < matlab.unittest.TestCase
     
     methods (TestMethodSetup)
         
-        function checkIfServerPresent(testCase)
+        function checkIfDockerPresent(testCase)
             [dockerExists, ~, result] = TbDockerStrategy.dockerExists();
             testCase.assumeTrue(dockerExists, result);
         end

--- a/test/TbNativeTest.m
+++ b/test/TbNativeTest.m
@@ -1,0 +1,49 @@
+classdef TbNativeTest < matlab.unittest.TestCase
+    % Test the TbNativeStrategy for finding system dependencies.
+    %
+    % The ToolboxToolbox should be able to determine if required native
+    % system dependencies are present, and "fail fast" at deployment time
+    % if missing.
+    %
+    % 2016-2017 benjamin.heasly@gmail.com
+    
+    methods (TestMethodSetup)
+        function checkIfGitPresent(testCase)
+            [status, result] = system('git --version');
+            gitExists = 0 == status;
+            testCase.assumeTrue(gitExists, result);
+        end
+    end
+    
+    methods (Test)
+        function testDependencyPresent(obj)
+            config = tbToolboxRecord( ...
+                'name', 'git', ...
+                'type', 'native', ...
+                'hook', 'TbNativeTest.checkForGit');
+            result = tbDeployToolboxes('config', config);
+            obj.assertEqual(result.status, 0);
+        end
+        
+        function testDependencyMissing(obj)
+            config = tbToolboxRecord( ...
+                'name', 'noSuchThing', ...
+                'type', 'native', ...
+                'hook', 'TbNativeTest.checkForNoSuchThing');
+            result = tbDeployToolboxes('config', config);
+            obj.assertNotEqual(result.status, 0);
+        end
+    end
+    
+    methods (Static)
+        function result = checkForGit()
+            [status, result] = system('git --version');
+            assert(0 == status, 'Please install Git (https://git-scm.com/)');
+        end
+        
+        function result = checkForNoSuchThing()
+            [status, result] = system('noSuchThing --version');
+            assert(0 == status, 'I''m sorry but there''s no such thing!');
+        end
+    end
+end


### PR DESCRIPTION
Would close #28 .

Adds a new TbNativeStrategy to allow checks for native system dependencies, using the toolbox record `hook` field.

Also see new section in wiki that documents the new toolbox type:
  https://github.com/ToolboxHub/ToolboxToolbox/wiki/Toolbox-Records-and-Types#native