### PR TITLE
Requirement hook field

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -242,7 +242,8 @@ for tt = 1:nToolboxes
     catch err
         status = -1;
         message = err.message;
-        advice = 'Please check that the function "%s" exists and has sinature [status, result, advice] = foo()';
+        advice = sprintf('Please check that the function "%s" exists and has signature [status, result, advice] = foo()', ...
+            record.requirementHook);
     end
     resolved(tt).status = status;
     resolved(tt).message = message;

--- a/api/tbToolboxRecord.m
+++ b/api/tbToolboxRecord.m
@@ -24,11 +24,14 @@ function record = tbToolboxRecord(varargin)
 %   add to path, instead of the whole toolbox
 %   - 'update' optional update control, if "never", won't attempt to update the toolbox
 %   - 'importance' optional error control, if "optional", errors with this
-%   toolbox won't cause the whole deployment to fail. 
-%   - 'hook' Matlab command to run after the toolbox is deployed and added
+%   toolbox won't cause the whole deployment to fail.
+%   - 'hook' Matlab command to eval() after the toolbox is deployed and added
 %   to the path
-%   - 'localHookTemplate' template for script with local config file to
-%   copy to the local hook folder and run at reploy time
+%   - 'requirementHook' name of a function to feval() that checks for
+%   system requirements that ToolboxToolbox can't install.  Must have the
+%   function signature: [status, result, advice] = foo()
+%   - 'localHookTemplate' relative path to config script template to be
+%   copied to the localHookFolder and run() at the end of deployment
 %   - 'toolboxRoot' where to deploy the toolbox, overrides toolboxRoot
 %   Matlab preference and toolboxRoot passed to tbDeployToolboxes().
 %   - 'pathPlacement' whether to 'append' or 'prepend' to the Matlab path.
@@ -45,6 +48,7 @@ parser.addParameter('flavor', '', @ischar);
 parser.addParameter('subfolder', '', @(val) ischar(val) || iscellstr(val));
 parser.addParameter('update', '', @ischar);
 parser.addParameter('hook', '', @ischar);
+parser.addParameter('requirementHook', '', @ischar);
 parser.addParameter('localHookTemplate', '', @ischar);
 parser.addParameter('toolboxRoot', '', @ischar);
 parser.addParameter('pathPlacement', 'append', @ischar);

--- a/test/TbRequirementHookTest.m
+++ b/test/TbRequirementHookTest.m
@@ -1,0 +1,105 @@
+classdef TbRequirementHookTest < matlab.unittest.TestCase
+    % Test the requiremetHook field for finding system dependencies.
+    %
+    % The ToolboxToolbox should be able to determine if system requirements
+    % are present, and "fail fast" at deployment time if not.
+    %
+    % 2016-2017 benjamin.heasly@gmail.com
+    
+    properties
+        testRepoUrl = 'https://github.com/ToolboxHub/sample-repo.git';
+        toolboxRoot = fullfile(tempdir(), 'toolboxes');
+        originalMatlabPath;
+    end
+    
+    methods (TestMethodSetup)
+        function checkIfGitPresent(testCase)
+            [status, result] = system('git --version');
+            gitExists = 0 == status;
+            testCase.assumeTrue(gitExists, result);
+        end
+        
+        function saveOriginalMatlabState(obj)
+            obj.originalMatlabPath = path();
+            tbResetMatlabPath('full');
+        end
+        
+        function cleanUpTempFiles(obj)
+            if 7 == exist(obj.toolboxRoot, 'dir')
+                rmdir(obj.toolboxRoot, 's');
+            end
+        end
+    end
+    
+    methods (TestMethodTeardown)
+        function restoreOriginalMatlabState(obj)
+            path(obj.originalMatlabPath);
+        end
+    end
+    
+    methods (Test)
+        function testRequirementPresent(obj)
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'requirementHook', 'TbRequirementHookTest.checkForGit', ...
+                'type', 'git');
+            result = tbDeployToolboxes( ...
+                'config', config, ...
+                'toolboxRoot', obj.toolboxRoot);
+            obj.assertEqual(result.status, 0);
+        end
+        
+        function testRequirementMissing(obj)
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'requirementHook', 'TbRequirementHookTest.checkForNoSuchThing', ...
+                'type', 'git');
+            result = tbDeployToolboxes( ...
+                'config', config, ...
+                'toolboxRoot', obj.toolboxRoot);
+            obj.assertNotEqual(result.status, 0);
+        end
+        
+        function testWrongHookSignature(obj)
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'requirementHook', 'TbRequirementHookTest.wrongSignature', ...
+                'type', 'git');
+            result = tbDeployToolboxes( ...
+                'config', config, ...
+                'toolboxRoot', obj.toolboxRoot);
+            obj.assertNotEqual(result.status, 0);
+        end
+        
+        function testHookMissing(obj)
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'requirementHook', 'thisIsNotAHook', ...
+                'type', 'git');
+            result = tbDeployToolboxes( ...
+                'config', config, ...
+                'toolboxRoot', obj.toolboxRoot);
+            obj.assertNotEqual(result.status, 0);
+        end
+    end
+    
+    methods (Static)
+        function [status, result, advice] = checkForGit()
+            [status, result] = system('git --version');
+            advice = 'Please install Git (https://git-scm.com/)';
+        end
+        
+        function [status, result, advice] = checkForNoSuchThing()
+            [status, result] = system('noSuchThing --version');
+            advice = 'Sorry, there is no such thing!';
+        end
+        
+        function wrongSignature()
+            disp('This function has the wrong signature!');
+        end
+    end
+end


### PR DESCRIPTION
Would close #28 .

Adds `requirementHook` field for toolbox records.  This holds the name of a function that can be used to check for system requirements that ToolboxToolbox doesn't know how to deploy.

Also see updated wiki documentation related to this field:
  https://github.com/ToolboxHub/ToolboxToolbox/wiki/Toolbox-Records-and-Types#all-types