### PR TITLE
Config snapshots

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -104,11 +104,6 @@ if isempty(config) || ~isstruct(config) || ~isfield(config, 'name')
 end
 
 
-%% Ignore records without names -- they're just comments.
-isComment = cellfun(@isempty, {config.name});
-config = config(~isComment);
-
-
 %% Convert registered toolbox names to "include" records.
 if ~isempty(registered)
     nRegistered = numel(registered);
@@ -125,6 +120,12 @@ if ~isempty(registered)
     end
 end
 
+
+%% Ignore records without names -- they're just comments.
+if ~isempty(config)
+    isComment = cellfun(@isempty, {config.name});
+    config = config(~isComment);
+end
 
 %% Single out one toolbox?
 if ~isempty(name)

--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -104,6 +104,11 @@ if isempty(config) || ~isstruct(config) || ~isfield(config, 'name')
 end
 
 
+%% Ignore records without names -- they're just comments.
+isComment = cellfun(@isempty, {config.name});
+config = config(~isComment);
+
+
 %% Convert registered toolbox names to "include" records.
 if ~isempty(registered)
     nRegistered = numel(registered);

--- a/api/tbDeploymentSnapshot.m
+++ b/api/tbDeploymentSnapshot.m
@@ -1,0 +1,79 @@
+function snapshot = tbDeploymentSnapshot(config, varargin)
+% Make a new config based on the given config, plus explicit flavors.
+%
+% The idea is to take an existing toolbox configuration and create a new
+% configuration that is "version-pinned" or "snapshot".  This is done by
+% trying to detect the deployed version number for each toolbox record in
+% the given configuration.  This will work best when the given
+% configuration has already been deployed.  For example:
+%   results = tbUse('sample-repo');
+%   snapshot = tbDeploymentSnapshot(results);
+%   tbWriteConfig(snapshot, 'conigPath', 'my-snapshot.json');
+%
+% snapshot = tbDeploymentSnapshot(config) attempts to detect the toolbox
+% version for each toolbox record in the given config.  Returns a new,
+% corresponding toolbox configuration in which the "flavor" field contains
+% the detected version for each toolbox.
+%
+% 2016 benjamin.heasly@gmail.com
+
+parser = inputParser();
+parser.KeepUnmatched = true;
+parser.PartialMatching = false;
+parser.addRequired('config', @isstruct);
+parser.parse(config);
+config = parser.Results.config;
+
+
+%% Gather version info for each toolbox.
+nToolboxes = numel(config);
+snapshotCell = cell(1, nToolboxes);
+for tt = 1:nToolboxes
+    record = config(tt);
+    strategy = tbChooseStrategy(record, varargin{:});
+    
+    if isempty(strategy)
+        continue;
+    end
+    
+    flavor = strategy.detectFlavor(record, varargin{:});
+    pinnedRecord = tbToolboxRecord(record, ...
+        'update', 'never', ...
+        'flavor', flavor);
+    snapshotCell{tt} = pinnedRecord;
+end
+
+
+%% Gather system-wide version info.
+systemInfo.matlab_ver = evalc('ver');
+systemInfo.matlab_version = version();
+systemInfo.java = version('-java');
+systemInfo.computer = computer();
+systemInfo.toolboxRegistry = detectRegistryFlavor(varargin{:});
+systemInfo.toolboxToolbox = detectSelfFlavor(varargin{:});
+
+% store in a bogus toolbox record, to be ignored by other functions
+systemRecord = tbToolboxRecord( ...
+    'importance', 'optional', ...
+    'type', 'system info');
+systemRecord.flavor = systemInfo;
+
+
+%% Results as struct array.
+snapshot = [systemRecord snapshotCell{:}];
+
+
+%% Try to detect the toolbox registry version.
+function registryFlavor = detectRegistryFlavor(varargin)
+registry = tbFetchRegistry(varargin{:}, 'doUpdate', false);
+registryFlavor = registry.strategy.detectFlavor(registry, varargin{:});
+
+
+%% Try to detect the ToolboxToolbox flavor, assuming it's with Git.
+function selfFlavor = detectSelfFlavor(varargin)
+self = tbToolboxRecord( ...
+    'toolboxRoot', fileparts(tbLocateSelf()), ...
+    'name', 'ToolboxToolbox', ...
+    'type', 'git');
+strategy = TbGitStrategy(varargin{:});
+selfFlavor = strategy.detectFlavor(self, varargin{:});

--- a/api/tbDeploymentSnapshot.m
+++ b/api/tbDeploymentSnapshot.m
@@ -60,7 +60,7 @@ systemRecord.extra = systemInfo;
 
 
 %% Results as struct array.
-snapshot = [systemRecord snapshotCell{:}];
+snapshot = [snapshotCell{:} systemRecord];
 
 
 %% Try to detect the toolbox registry version.
@@ -76,7 +76,7 @@ self = tbToolboxRecord( ...
     'toolboxRoot', fileparts(tbLocateSelf()), ...
     'name', 'ToolboxToolbox', ...
     'type', 'git');
-strategy = TbGitStrategy(varargin{:});
+strategy = tbChooseStrategy(self, varargin{:});
 flavor = strategy.detectFlavor(self, varargin{:});
 url = strategy.detectOriginUrl(self, varargin{:});
 selfInfo = tbToolboxRecord(self, 'flavor', flavor, 'url', url);

--- a/api/tbReadConfig.m
+++ b/api/tbReadConfig.m
@@ -65,9 +65,6 @@ for tt = 1:nToolboxes
         record = rawConfig(tt);
     end
     
-    if ~isstruct(record) || ~isfield(record, 'name') || isempty(record.name)
-        continue;
-    end
     wellFormedRecords{tt} = tbToolboxRecord(record);
 end
 config = [wellFormedRecords{:}];

--- a/api/tbToolboxRecord.m
+++ b/api/tbToolboxRecord.m
@@ -24,7 +24,7 @@ function record = tbToolboxRecord(varargin)
 %   add to path, instead of the whole toolbox
 %   - 'update' optional update control, if "never", won't attempt to update the toolbox
 %   - 'importance' optional error control, if "optional", errors with this
-%   toolbox won't cause the whole deployment to fail. 
+%   toolbox won't cause the whole deployment to fail.
 %   - 'hook' Matlab command to run after the toolbox is deployed and added
 %   to the path
 %   - 'localHookTemplate' template for script with local config file to
@@ -33,6 +33,8 @@ function record = tbToolboxRecord(varargin)
 %   Matlab preference and toolboxRoot passed to tbDeployToolboxes().
 %   - 'pathPlacement' whether to 'append' or 'prepend' to the Matlab path.
 %   The default is to 'append'.
+%   - 'extra' a free-form field for notes, comments, etc., ignored during
+%   deployment
 %
 % 2016 benjamin.heasly@gmail.com
 
@@ -49,6 +51,7 @@ parser.addParameter('localHookTemplate', '', @ischar);
 parser.addParameter('toolboxRoot', '', @ischar);
 parser.addParameter('pathPlacement', 'append', @ischar);
 parser.addParameter('importance', '', @ischar);
+parser.addParameter('extra', '');
 parser.parse(varargin{:});
 
 % let the parser do all the work

--- a/api/tbWriteConfig.m
+++ b/api/tbWriteConfig.m
@@ -29,9 +29,6 @@ nToolboxes = numel(config);
 wellFormedRecords = cell(1, nToolboxes);
 for tt = 1:nToolboxes
     record = config(tt);
-    if ~isfield(record, 'name') || isempty(record.name)
-        continue;
-    end
     wellFormedRecords{tt} = tbToolboxRecord(record);
 end
 records = [wellFormedRecords{:}];

--- a/strategies/TbGitStrategy.m
+++ b/strategies/TbGitStrategy.m
@@ -60,12 +60,12 @@ classdef TbGitStrategy < TbToolboxStrategy
             [status, message, fullCommand] = obj.systemInFolder(command, toolboxPath);
         end
         
-        function [status, result, fullCommand] = systemInFolder(obj, command, folder)
+        function [status, result, fullCommand] = systemInFolder(obj, command, folder, varargin)
             originalFolder = pwd();
             try
                 obj.checkInternet('asAssertion', true);
                 cd(folder);
-                [status, result, fullCommand] = tbSystem(command);
+                [status, result, fullCommand] = tbSystem(command, varargin{:});
             catch err
                 status = -1;
                 result = err.message;
@@ -74,5 +74,23 @@ classdef TbGitStrategy < TbToolboxStrategy
             cd(originalFolder);
         end
         
+        function flavor = detectFlavor(obj, record, varargin)
+            % preserve declared flavor, if any
+            if ~isempty(record.flavor)
+                flavor = record.flavor;
+                return;
+            end
+            
+            % detect flavor with git command.
+            toolboxPath = tbLocateToolbox(record, varargin{:});
+            command = 'git rev-parse HEAD';
+            [status, result] = obj.systemInFolder(command, toolboxPath, ...
+                'echo', false);
+            if 0 == status
+                flavor = strtrim(result);
+            else
+                flavor = '';
+            end
+        end
     end
 end

--- a/strategies/TbGitStrategy.m
+++ b/strategies/TbGitStrategy.m
@@ -92,5 +92,18 @@ classdef TbGitStrategy < TbToolboxStrategy
                 flavor = '';
             end
         end
+        
+        function url = detectOriginUrl(obj, record, varargin)            
+            % try to detect the url from where this was cloned
+            toolboxPath = tbLocateToolbox(record, varargin{:});
+            command = 'git config --get remote.origin.url';
+            [status, result] = obj.systemInFolder(command, toolboxPath, ...
+                'echo', false);
+            if 0 == status
+                url = strtrim(result);
+            else
+                url = '';
+            end
+        end
     end
 end

--- a/strategies/TbGitStrategy.m
+++ b/strategies/TbGitStrategy.m
@@ -85,6 +85,7 @@ classdef TbGitStrategy < TbToolboxStrategy
             toolboxPath = tbLocateToolbox(record, varargin{:});
             command = 'git rev-parse HEAD';
             [status, result] = obj.systemInFolder(command, toolboxPath, ...
+                varargin{:}, ...
                 'echo', false);
             if 0 == status
                 flavor = strtrim(result);
@@ -98,6 +99,7 @@ classdef TbGitStrategy < TbToolboxStrategy
             toolboxPath = tbLocateToolbox(record, varargin{:});
             command = 'git config --get remote.origin.url';
             [status, result] = obj.systemInFolder(command, toolboxPath, ...
+                varargin{:}, ...
                 'echo', false);
             if 0 == status
                 url = strtrim(result);

--- a/strategies/TbSvnStrategy.m
+++ b/strategies/TbSvnStrategy.m
@@ -88,6 +88,7 @@ classdef TbSvnStrategy < TbToolboxStrategy
             toolboxPath = tbLocateToolbox(record, varargin{:});
             command = 'svn info';
             [status, result] = obj.systemInFolder(command, toolboxPath, ...
+                varargin{:}, ...
                 'echo', false);
             if 0 == status
                 % scrape out just the revision number

--- a/strategies/TbSvnStrategy.m
+++ b/strategies/TbSvnStrategy.m
@@ -63,18 +63,43 @@ classdef TbSvnStrategy < TbToolboxStrategy
             [status, message, fullCommand] = obj.systemInFolder(command, toolboxPath);
         end
         
-        function [status, result, fullCommand] = systemInFolder(obj, command, folder)
+        function [status, result, fullCommand] = systemInFolder(obj, command, folder, varargin)
             originalFolder = pwd();
             try
                 obj.checkInternet('asAssertion', true);
                 cd(folder);
-                [status, result, fullCommand] = tbSystem(command);
+                [status, result, fullCommand] = tbSystem(command, varargin{:});
             catch err
                 status = -1;
                 result = err.message;
                 fullCommand = command;
             end
             cd(originalFolder);
+        end
+        
+        function flavor = detectFlavor(obj, record, varargin)
+            % preserve declared flavor, if any
+            if ~isempty(record.flavor)
+                flavor = record.flavor;
+                return;
+            end
+            
+            % detect flavor with svn command.
+            toolboxPath = tbLocateToolbox(record, varargin{:});
+            command = 'svn info';
+            [status, result] = obj.systemInFolder(command, toolboxPath, ...
+                'echo', false);
+            if 0 == status
+                % scrape out just the revision number
+                tokens = regexp(result, '^Revision: (\d+)$', ...
+                    'tokens', ...
+                    'lineanchors');
+                if ~isempty(tokens)
+                    flavor = tokens{1}{1};
+                    return;
+                end
+            end
+            flavor = '';
         end
     end
 end

--- a/strategies/TbToolboxStrategy.m
+++ b/strategies/TbToolboxStrategy.m
@@ -24,7 +24,7 @@ classdef TbToolboxStrategy < handle
     
     methods
         function [toolboxPath, displayName] = toolboxPath(obj, toolboxRoot, record, varargin)
-            % default: standard folder instide toolboxRoot
+            % default: standard folder inside toolboxRoot
             [toolboxPath, displayName] = tbToolboxPath(toolboxRoot, record, varargin{:});
         end
         

--- a/strategies/TbToolboxStrategy.m
+++ b/strategies/TbToolboxStrategy.m
@@ -44,5 +44,10 @@ classdef TbToolboxStrategy < handle
                 'checkInternetCommand', obj.checkInternetCommand, ...
                 varargin{:});
         end
+        
+        function flavor = detectFlavor(obj, record, varargin)
+            % default: just report the original declared flavor
+            flavor = record.flavor;
+        end
     end
 end

--- a/test/TbSnapshotTest.m
+++ b/test/TbSnapshotTest.m
@@ -1,0 +1,157 @@
+classdef TbSnapshotTest < matlab.unittest.TestCase
+    % Test the ToolboxToolbox deployment snapshots
+    %
+    % The Toolbox Toolbox should be able to detect versions/flavors for the
+    % system and deployed toolboxes, and write new configurations that
+    % includes the versions/flavors.
+    %
+    % 2016 benjamin.heasly@gmail.com
+    
+    properties
+        testRepoUrl = 'https://github.com/ToolboxHub/sample-repo.git';
+        toolboxRoot = fullfile(tempdir(), 'toolboxes');
+        originalMatlabPath;
+    end
+    
+    methods (TestMethodSetup)
+        function saveOriginalMatlabState(obj)
+            obj.originalMatlabPath = path();
+            tbResetMatlabPath('full');
+        end
+        
+        function cleanUpTempFiles(obj)
+            if 7 == exist(obj.toolboxRoot, 'dir')
+                rmdir(obj.toolboxRoot, 's');
+            end
+        end
+    end
+    
+    methods (TestMethodTeardown)
+        function restoreOriginalMatlabState(obj)
+            path(obj.originalMatlabPath);
+        end
+    end
+    
+    methods (Test)
+        function testReadWriteSystemInfo(obj)
+            % deploy and make a snapshot
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'type', 'git');
+            originalResult = tbDeployToolboxes( ...
+                'config', config, ...
+                'toolboxRoot', obj.toolboxRoot);
+            obj.assertEqual(originalResult.status, 0);
+            snapshot = tbDeploymentSnapshot(originalResult, ...
+                'toolboxRoot', obj.toolboxRoot);
+            
+            % snapshot should contain some system info at the end
+            obj.assertNumElements(snapshot, 2);
+            systemInfo = snapshot(2);
+            obj.assertInstanceOf(systemInfo.extra, 'struct');
+            obj.assertEqual(systemInfo.extra.matlab_version, version());
+            
+            % system info should survive a JSON read-write cycle
+            snapshotPath = fullfile(obj.toolboxRoot, 'snapshot.json');
+            tbWriteConfig(snapshot, 'configPath', snapshotPath);
+            snapshotAgain = tbReadConfig('configPath', snapshotPath);
+            
+            % want to compare 
+            %   obj.assertEqual(snapshotAgain, snapshot);
+            % but get false negatives like
+            %   Actual char:
+            %     Empty matrix: 1-by-0
+            %   Expected char:
+            %     ''
+
+            % reasonable but weaker test than what I want above :-(
+            obj.assertNumElements(snapshotAgain, 2);
+            systemInfoAgain = snapshotAgain(2);
+            obj.assertEqual( ...
+                systemInfoAgain.extra.matlab_version, ...
+                systemInfo.extra.matlab_version);
+        end
+        
+        function testGitHead(obj)
+            % use repository head revision
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'type', 'git');
+            obj.deployAndCheckFlavors(config);
+        end
+        
+        function testGitCommit(obj)
+            % use repository head revision
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'flavor', '4da2f4d4de07d8de7df763d77d2b2daa008425f4', ...
+                'type', 'git');
+            obj.deployAndCheckFlavors(config);
+        end
+        
+        function testSvnHead(obj)
+            % use repository head revision
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'subfolder', 'trunk', ...
+                'type', 'svn');
+            obj.deployAndCheckFlavors(config);
+        end
+        
+        function testSvnRevision(obj)
+            % use specific repository revision
+            config = tbToolboxRecord( ...
+                'name', 'simple', ...
+                'url', obj.testRepoUrl, ...
+                'flavor', '5', ...
+                'subfolder', 'trunk', ...
+                'type', 'svn');
+            obj.deployAndCheckFlavors(config);
+        end
+    end
+    
+    methods
+        function deployAndCheckFlavors(obj, config)
+            % deploy normally
+            originalResult = tbDeployToolboxes( ...
+                'config', config, ...
+                'toolboxRoot', obj.toolboxRoot);
+            obj.assertEqual(originalResult.status, 0);
+            
+            % detect deployed version
+            strategy = tbChooseStrategy(config);
+            deployedFlavor = strategy.detectFlavor(originalResult, ...
+                'toolboxRoot', obj.toolboxRoot);
+            
+            % if given, declared flavor should match detected flavor
+            if ~isempty(config.flavor)
+                obj.assertEqual(deployedFlavor, config.flavor);
+            end
+            
+            % make a "snapshot" config
+            snapshot = tbDeploymentSnapshot(originalResult, ...
+                'toolboxRoot', obj.toolboxRoot);
+            
+            % snapshot version should match deployed version
+            obj.assertEqual(snapshot(1).flavor, deployedFlavor);
+            
+            % redeploy from the snapshot
+            snapshotResult = tbDeployToolboxes( ...
+                'config', snapshot, ...
+                'toolboxRoot', obj.toolboxRoot, ...
+                'reset', 'full');
+            obj.assertEqual(snapshotResult.status, 0);
+            
+            % detect redeployed version directly
+            redeployedFlavor = strategy.detectFlavor(snapshotResult, ...
+                'toolboxRoot', obj.toolboxRoot);
+            
+            % redeployed version should matchsnapshot version
+            obj.assertEqual(redeployedFlavor, snapshot(1).flavor);
+        end
+    end
+end


### PR DESCRIPTION
Would close #34 .

Adds `extra` field for toolbox records to contain arbitrary info, like comments.
Allows nameless toolbox records to be written to/read from JSON, and to be ignored during deployment. 

Adds `tbDeploymentSnapshot()` to generate a "snapshot" toolbox config based on a given config
 - with Git or Svn versions filled into each `flavor` field
 - with an appended, nameless record whose `extra` field contains system information, like the Matlab and OS versions

Addes tests for above. 
