### PR TITLE
Deploy to folder

### DIFF
--- a/api/tbDeployToFolder.m
+++ b/api/tbDeployToFolder.m
@@ -1,0 +1,45 @@
+function results = tbDeployToFolder(rootFolder, varargin)
+% Deploy toolboxes to a given rootFolder, instead of toolboxRoot.
+%
+% This is a convenience wrapper around tbDeployToolboxes().  It deployes
+% toolboxes to the given rootFolder, regardless of the currently configured
+% toolboxCommonRoot, toolboxRoot, or projectRoot, or any toolboxRoot field
+% specified in toolbox records.  This is useful for temporary deployments
+% that should be kept separate from regular toolboxes and proects, and
+% should be easy to delete.
+%
+% results = tbDeployToFolder() fetches each toolbox from the default
+% toolbox configuration into the given rootFolder and adds each to the
+% Matlab path.  Returns a struct of results about what happened for each
+% toolbox.
+%
+% tbDeployToFolder(... 'config', config) deploy the given struct array of
+% toolbox records instead of the default toolbox configuration.
+%
+% This function uses ToolboxToolbox shared parameters and preferences.  See
+% tbParsePrefs().
+%
+% 2017 benjamin.heasly@gmail.com
+
+[prefs, others] = tbParsePrefs(varargin{:});
+
+parser = inputParser();
+parser.addRequired('rootFolder', @ischar);
+parser.addParameter('config', [], @(c) isempty(c) || isstruct(c));
+parser.parse(rootFolder, others);
+rootFolder = parser.Results.rootFolder;
+config = parser.Results.config;
+
+
+%% Choose explicit config, or load from file.
+if isempty(config) || ~isstruct(config) || ~isfield(config, 'name')
+    config = tbReadConfig(prefs);
+end
+
+%% Put all toolboxes into the given root folder.
+config = tbDealField(config, 'toolboxRoot', rootFolder);
+prefs.toolboxCommonRoot = rootFolder;
+
+
+%% The rest of the deployment is the same as usual.
+results = tbDeployToolboxes('config', config, prefs);

--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -13,6 +13,9 @@ function [resolved, included] = tbDeployToolboxes(varargin)
 % This function uses ToolboxToolbox shared parameters and preferences.  See
 % tbParsePrefs().
 %
+% tbDeployToolboxes(... 'config', config) deploy the given struct array of
+% toolbox records instead of the default toolbox configuration.
+%
 % tbDeployToolboxes(... 'name', name) specify the name of a single toolbox
 % to deploy if found.  Other toolboxes will be ignored.
 %

--- a/api/tbDeploymentSnapshot.m
+++ b/api/tbDeploymentSnapshot.m
@@ -8,7 +8,8 @@ function snapshot = tbDeploymentSnapshot(config, varargin)
 % configuration has already been deployed.  For example:
 %   results = tbUse('sample-repo');
 %   snapshot = tbDeploymentSnapshot(results);
-%   tbWriteConfig(snapshot, 'consfigPath', 'my-snapshot.json');
+%   tbWriteConfig(snapshot, 'configPath', 'my-snapshot.json');
+%   tbDeployToFolder('~/my-folder', 'configPath', 'my-snapshot.json');
 %
 % snapshot = tbDeploymentSnapshot(config) attempts to detect the toolbox
 % version for each toolbox record in the given config.  Returns a new,

--- a/api/tbLocateToolbox.m
+++ b/api/tbLocateToolbox.m
@@ -28,21 +28,30 @@ else
 end
 strategy = tbChooseStrategy(record, prefs);
 
-% first, look for a pre-installed toolbox
+% first, look for a toolbox or project in its own, explicit location
+if ~isempty(record.toolboxRoot)
+    toolboxRoot = record.toolboxRoot;
+    [toolboxPath, displayName] = strategy.toolboxPath(toolboxRoot, record);
+    if strategy.checkIfPresent(record, toolboxRoot, toolboxPath)
+        return;
+    end
+end
+
+% second, look for a pre-installed toolbox
 toolboxRoot = prefs.toolboxCommonRoot;
 [toolboxPath, displayName] = strategy.toolboxPath(toolboxRoot, record);
 if strategy.checkIfPresent(record, toolboxRoot, toolboxPath)
     return;
 end
 
-% then look for a regular toolbox
+% last, look for a regular toolbox
 toolboxRoot = prefs.toolboxRoot;
 [toolboxPath, displayName] = strategy.toolboxPath(toolboxRoot, record);
 if strategy.checkIfPresent(record, toolboxRoot, toolboxPath)
     return;
 end
 
-% didn't find the toolbox
+% alas, didn't find the toolbox
 toolboxPath = '';
 displayName = record.name;
 toolboxRoot = '';


### PR DESCRIPTION
New function `tbDeployToFolder()` to deploy configurations to a specific folder.  This makes it easier to work with alternative or temporary configurations that are kept separate from the usual toolbox and project folders.

This is a good pairing with `tbDeploymentSnapshot()`, to deploy a snapshot configuration to a temporary folder, use it for a while, then delete it.
