### PR TITLE
proceed with deployment even when offline

### DIFF
--- a/api/tbCheckInternet.m
+++ b/api/tbCheckInternet.m
@@ -19,7 +19,6 @@ function [isOnline, result] = tbCheckInternet(varargin)
 
 % caller wants to skip the check?
 if isempty(prefs.checkInternetCommand)
-    fprintf('Skipping internet check.\n');
     isOnline = true;
     result = 'skipping internet check';
     return;

--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -83,12 +83,17 @@ end
 %% Get or update the toolbox registry.
 registry = tbFetchRegistry(prefs, 'doUpdate', true);
 if 0 ~= registry.status
-    fprintf('Unable to fetch toolbox registry "%s".\n', registry.name);
-    fprintf('  command was: %s.\n', registry.command);
-    fprintf('  message was: %s\n', registry.message);
-    resolved = [];
-    included = [];
-    return;
+    registryPath = tbLocateToolbox(registry, prefs);
+    if isempty(registryPath)
+        fprintf('Unable to fetch toolbox registry "%s".\n', registry.name);
+        fprintf('  command was: %s.\n', registry.command);
+        fprintf('  message was: %s\n', registry.message);
+        resolved = [];
+        included = [];
+        return;
+    else
+        fprintf('Unable to update toolbox registry "%s", proceeding with current version.\n', registry.name);
+    end
 end
 
 

--- a/strategies/TbDockerStrategy.m
+++ b/strategies/TbDockerStrategy.m
@@ -42,7 +42,12 @@ classdef TbDockerStrategy < TbToolboxStrategy
         end
         
         function [command, status, message] = update(obj, record, toolboxRoot, toolboxPath)
-            % just keep obtaining.  Use record.neverUpdate to prevent this.
+            if ~obj.checkInternet('echo', false)
+                % toolbox already exists, but offline prevents update
+                [command, status, message] = obj.skipUpdate();
+                return;
+            end
+            
             [command, status, message] = obj.obtain(record, toolboxRoot, toolboxPath);
         end
     end

--- a/strategies/TbGitStrategy.m
+++ b/strategies/TbGitStrategy.m
@@ -48,6 +48,12 @@ classdef TbGitStrategy < TbToolboxStrategy
         
         function [fullCommand, status, message] = update(obj, record, toolboxRoot, toolboxPath)
             
+            if ~obj.checkInternet('echo', false)
+                % toolbox already exists, but offline prevents update
+                [fullCommand, status, message] = obj.skipUpdate();
+                return;
+            end
+            
             % fail fast if git is not working
             TbGitStrategy.assertGitWorks();
             

--- a/strategies/TbSvnStrategy.m
+++ b/strategies/TbSvnStrategy.m
@@ -47,6 +47,12 @@ classdef TbSvnStrategy < TbToolboxStrategy
         
         function [fullCommand, status, message] = update(obj, record, toolboxRoot, toolboxPath)
             
+            if ~obj.checkInternet('echo', false)
+                % toolbox already exists, but offline prevents update
+                [fullCommand, status, message] = obj.skipUpdate();
+                return;
+            end
+            
             % fail fast if svn is not working
             TbSvnStrategy.assertSvnWorks();
             

--- a/strategies/TbToolboxStrategy.m
+++ b/strategies/TbToolboxStrategy.m
@@ -45,5 +45,12 @@ classdef TbToolboxStrategy < handle
             % default: just report the original declared flavor
             flavor = record.flavor;
         end
+        
+        function [command, status, message] = skipUpdate(obj)
+            status = 0;
+            command = 'checkInternet()';
+            message = 'Proceeding without update.';
+            fprintf('Proceeding without update.\n');
+        end
     end
 end

--- a/strategies/TbWebGetStrategy.m
+++ b/strategies/TbWebGetStrategy.m
@@ -8,7 +8,7 @@ classdef TbWebGetStrategy < TbToolboxStrategy
         
         function [command, status, message] = obtain(obj, record, toolboxRoot, toolboxPath)
             
-            try                
+            try
                 command = 'mkdir';
                 if 7 ~= exist(toolboxPath, 'dir')
                     mkdir(toolboxPath);
@@ -17,7 +17,7 @@ classdef TbWebGetStrategy < TbToolboxStrategy
                 command = 'websave';
                 [~, resourceBase, resourceExt] = fileparts(record.url);
                 fileName = fullfile(toolboxPath, [resourceBase, resourceExt]);
-               
+                
                 obj.checkInternet('asAssertion', true);
                 fileName = websave(fileName, record.url);
                 
@@ -38,7 +38,12 @@ classdef TbWebGetStrategy < TbToolboxStrategy
         end
         
         function [command, status, message] = update(obj, record, toolboxRoot, toolboxPath)
-            % just keep obtaining.  Use record.neverUpdate to prevent this.
+            if ~obj.checkInternet('echo', false)
+                % toolbox already exists, but offline prevents update
+                [command, status, message] = obj.skipUpdate();
+                return;
+            end
+            
             [command, status, message] = obj.obtain(record, toolboxRoot, toolboxPath);
         end
     end


### PR DESCRIPTION
Allows deployments to proceed even when offline.  I thought this was already the case, but it got broken at some point.

This will still display error messages about failed `git pull` and similar.  But It will still add toolboxes to the Matlab path and print messages about that, too.

Would close #53 .