### PR TITLE
Null path placement

### DIFF
--- a/api/tbAddToPath.m
+++ b/api/tbAddToPath.m
@@ -20,13 +20,23 @@ parser.parse(rootFolder, varargin{:});
 rootFolder = tbHomePathToAbsolute(parser.Results.rootFolder);
 pathPlacement = parser.Results.pathPlacement;
 
+if strcmp('none', pathPlacement)
+    % skip path generation, report current path
+    oldPath = path();
+    return;
+end
+
 % all subfolders of given toolboxPath, except cruft like .git
 allFolders = genpath(rootFolder);
 cleanFolders = tbCleanPath(allFolders);
 
-% prepend or append to existing Matlab path
-if strcmp(pathPlacement, 'prepend')
-    oldPath = addpath(cleanFolders, '-begin');
-else
-    oldPath = addpath(cleanFolders, '-end');
+% prepend or append to existing Matlab path?
+switch pathPlacement
+    case 'prepend'
+        oldPath = addpath(cleanFolders, '-begin');
+    case 'append'
+        oldPath = addpath(cleanFolders, '-end');
+    otherwise
+        % default is append
+        oldPath = addpath(cleanFolders, '-end');
 end

--- a/api/tbToolboxRecord.m
+++ b/api/tbToolboxRecord.m
@@ -33,8 +33,9 @@ function record = tbToolboxRecord(varargin)
 %   copied to the localHookFolder and run() at the end of deployment
 %   - 'toolboxRoot' where to deploy the toolbox, overrides toolboxRoot
 %   Matlab preference and toolboxRoot passed to tbDeployToolboxes().
-%   - 'pathPlacement' whether to 'append' or 'prepend' to the Matlab path.
-%   The default is to 'append'.
+%   - 'pathPlacement' whether to 'append' or 'prepend' to the Matlab path,
+%   or skip adding to the path altogether with 'none'.  The default is to
+%   'append'.
 %   - 'extra' a free-form field for notes, comments, etc., ignored during
 %   deployment
 %

--- a/strategies/TbInstalledStrategy.m
+++ b/strategies/TbInstalledStrategy.m
@@ -34,14 +34,23 @@ classdef TbInstalledStrategy < TbToolboxStrategy
         end
         
         function toolboxPath = addToPath(obj, record, toolboxPath)
+            if strcmp('none', record.pathPlacement)
+                % skip path construction and adding
+                return;
+            end
+            
             % start with folders that come from Matlab's own default path
-            % filter to those that match the name of this toolbox
+            % filter to get the ones that match the name of this toolbox
             toolboxPath = toolboxdir(record.name);
             toolboxPathEntries = TbInstalledStrategy.factoryPathMatches(toolboxPath);
-            if strcmp(record.pathPlacement, 'prepend')
-                addpath(toolboxPathEntries, '-begin');
-            else
-                addpath(toolboxPathEntries, '-end');
+            switch record.pathPlacement
+                case 'prepend'
+                    addpath(toolboxPathEntries, '-begin');
+                case 'append'
+                    addpath(toolboxPathEntries, '-end');
+                otherwise
+                    % default is append
+                    addpath(toolboxPathEntries, '-end');
             end
         end
     end

--- a/test/TbGitAndSanityTest.m
+++ b/test/TbGitAndSanityTest.m
@@ -231,9 +231,21 @@ classdef TbGitAndSanityTest < matlab.unittest.TestCase
                 'reset', 'full');
             obj.assertTrue(all(0 == [results.status]));
             
-            % should not have altered the path
+            % should not have any of these toolboxes to the path
             deployedPath = path();
-            obj.assertEqual(deployedPath, obj.originalMatlabPath);
+            nToolboxes = numel(config);
+            for tt = 1:nToolboxes
+                toolboxDir = tbLocateToolbox(results(tt), ...
+                    'toolboxRoot', obj.toolboxRoot);
+                
+                % toolbox was deployed, so toolboxDir should exist
+                obj.assertEqual(exist(toolboxDir, 'dir'), 7);
+                
+                % but toolboxDir should not be on the Matlab path
+                pathIndex = strfind(deployedPath, toolboxDir);
+                obj.assertEmpty(pathIndex);
+            end
+            
         end
         
         function testOptionalToolbox(obj)

--- a/test/TbGitAndSanityTest.m
+++ b/test/TbGitAndSanityTest.m
@@ -222,6 +222,20 @@ classdef TbGitAndSanityTest < matlab.unittest.TestCase
             end
         end
         
+        function testPathNone(obj)
+            config = obj.createConfig();
+            [config.pathPlacement] = deal('none');
+            results = tbDeployToolboxes( ...
+                'config', config, ...
+                'toolboxRoot', obj.toolboxRoot, ...
+                'reset', 'full');
+            obj.assertTrue(all(0 == [results.status]));
+            
+            % should not have altered the path
+            deployedPath = path();
+            obj.assertEqual(deployedPath, obj.originalMatlabPath);
+        end
+        
         function testOptionalToolbox(obj)
             % make the first record fail
             config = obj.createConfig();

--- a/test/TbInstalledTest.m
+++ b/test/TbInstalledTest.m
@@ -1,8 +1,8 @@
 classdef TbInstalledTest  < matlab.unittest.TestCase
-    % Test the Toolbox Toolbox against installed Matlab toolboxes.
+    % Test ToolboxToolbox against installed Matlab toolboxes.
     %
-    % The Toolbox Toolbox should be able to manage the matlab path built-in
-    % matlab toolboxes
+    % ToolboxToolbox should be able to manage the matlab path for installed
+    % Matlab toolboxes.
     %
     % 2016 benjamin.heasly@gmail.com
     
@@ -24,16 +24,16 @@ classdef TbInstalledTest  < matlab.unittest.TestCase
     end
     
     methods (Test)
-        function testCoreBuiltins(obj)
+        function testExcludeAndRestore(obj)
             % find an installed function
             %   so we need imageprocessing installed do this test
-            whichImageinfo = which('imageinfo');
-            obj.assertEqual(exist(whichImageinfo, 'file'), 2);
+            originalImageInfo = which('imageinfo');
+            obj.assertEqual(exist(originalImageInfo, 'file'), 2);
             
             % exclude it from the path
             tbResetMatlabPath('reset', 'no-matlab');
-            whichImageinfo = which('imageinfo');
-            obj.assertEqual(exist(whichImageinfo, 'file'), 0);
+            whichImageInfo = which('imageinfo');
+            obj.assertEmpty(whichImageInfo);
             
             % return it to the path
             record = tbToolboxRecord( ...
@@ -43,8 +43,32 @@ classdef TbInstalledTest  < matlab.unittest.TestCase
                 'config', record, ...
                 'reset', 'no-matlab');
             obj.assertEqual(results.status, 0);
-            whichImageinfo = which('imageinfo');
-            obj.assertEqual(exist(whichImageinfo, 'file'), 2);
+            whichImageInfo = which('imageinfo');
+            obj.assertEqual(whichImageInfo, originalImageInfo);
+        end
+        
+        function testExcludeNoRestore(obj)
+            % find an installed function
+            %   so we need imageprocessing installed do this test
+            originalImageInfo = which('imageinfo');
+            obj.assertEqual(exist(originalImageInfo, 'file'), 2);
+            
+            % exclude it from the path
+            tbResetMatlabPath('reset', 'no-matlab');
+            whichImageInfo = which('imageinfo');
+            obj.assertEmpty(whichImageInfo);
+            
+            % deploy but don't add to the path!
+            record = tbToolboxRecord( ...
+                'type', 'installed', ...
+                'name', 'images', ...
+                'pathPlacement', 'none');
+            results = tbDeployToolboxes( ...
+                'config', record, ...
+                'reset', 'no-matlab');
+            obj.assertEqual(results.status, 0);
+            whichImageInfo = which('imageinfo');
+            obj.assertEmpty(whichImageInfo);
         end
     end
 end


### PR DESCRIPTION
Would close #56 .

Adds the new option `none` for the toolbox record `pathPlacement` field.  Toolboxes and projects that declare `pathPlacement` = `none` will not be added to the Matlab path.

See also the updated wiki page on [Toolbox Records and Types](https://github.com/ToolboxHub/ToolboxToolbox/wiki/Toolbox-Records-and-Types#all-types) which now mentions the new `none` option.