### PR TITLE
Add isstring for the subfolder parameter

### DIFF
--- a/api/tbToolboxRecord.m
+++ b/api/tbToolboxRecord.m
@@ -47,7 +47,7 @@ parser.addParameter('name', '', @ischar);
 parser.addParameter('url', '', @ischar);
 parser.addParameter('type', '', @ischar);
 parser.addParameter('flavor', '', @ischar);
-parser.addParameter('subfolder', '', @(val) ischar(val) || iscellstr(val));
+parser.addParameter('subfolder', '', @(val) ischar(val) || iscellstr(val) || isstring(val));
 parser.addParameter('update', '', @ischar);
 parser.addParameter('hook', '', @ischar);
 parser.addParameter('requirementHook', '', @ischar);


### PR DESCRIPTION
MATLAB 2016b introduced a new String array data type, which is not captured by `ischar(val)` or `iscellstr(val)`, causing this function to fail when there are multiple subfolders specified in the JSON file. `isstring(val)` circumvents this issue.