### PR TITLE
control when to update the toolboxes / speedup

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -107,7 +107,7 @@ end
 
 
 %% Get or update the toolbox registry.
-registry = tbFetchRegistry(prefs, 'doUpdate', true);
+registry = tbFetchRegistry(prefs, 'doUpdate', prefs.updateRegistry);
 if 0 ~= registry.status
     registryPath = tbLocateToolbox(registry, prefs);
     if isempty(registryPath)

--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -48,22 +48,24 @@ if isempty(config) || ~isstruct(config) || ~isfield(config, 'name')
     config = tbReadConfig(prefs);
 end
 
-%% Check whether TbTb itself is up-to-date, and report status
-self = tbToolboxRecord( ...
-    'toolboxRoot', fileparts(tbLocateSelf()), ...
-    'name', 'ToolboxToolbox', ...
-    'type', 'git');
-strategy = tbChooseStrategy(self, prefs);
-[flavor,flavorlong,originflavorlong] = strategy.detectFlavor(self);
-if (isempty(flavorlong))
-    if (prefs.verbose) fprintf(2,'Cannot detect local ToolboxToolbox revision number and thus cannot tell if it is up to date\n\n'); end
-elseif (isempty(originflavorlong))
-    if (prefs.verbose) fprintf(2,'Cannot detect ToolboxToolbox revision number on gitHub and thus cannot tell if local copy is up to date\n\n'); end
-elseif (strcmp(flavorlong,originflavorlong))
-    if (prefs.verbose) fprintf('Local copy of ToolboxToolbox is up to date.\n'); end
-else
-    if (prefs.verbose) fprintf(2,'Local copy of ToolboxToolbox out of date (or you made local modifications).\n'); end
-    if (prefs.verbose) fprintf(2,'Consider updating with git pull or otherwise synchronizing.\n\n'); end
+% Check whether TbTb itself is up-to-date, and report status
+if prefs.updateTbTb
+    self = tbToolboxRecord( ...
+        'toolboxRoot', fileparts(tbLocateSelf()), ...
+        'name', 'ToolboxToolbox', ...
+        'type', 'git');
+    strategy = tbChooseStrategy(self, prefs);
+    [~, flavorlong,originflavorlong] = strategy.detectFlavor(self);
+    if (isempty(flavorlong))
+        if (prefs.verbose), fprintf(2,'Cannot detect local ToolboxToolbox revision number and thus cannot tell if it is up to date\n\n'); end
+    elseif (isempty(originflavorlong))
+        if (prefs.verbose), fprintf(2,'Cannot detect ToolboxToolbox revision number on gitHub and thus cannot tell if local copy is up to date\n\n'); end
+    elseif (strcmp(flavorlong,originflavorlong))
+        if (prefs.verbose), fprintf('Local copy of ToolboxToolbox is up to date.\n'); end
+    else
+        if (prefs.verbose), fprintf(2,'Local copy of ToolboxToolbox out of date (or you made local modifications).\n'); end
+        if (prefs.verbose), fprintf(2,'Consider updating with git pull or otherwise synchronizing.\n\n'); end
+    end
 end
 
 %% Convert registered toolbox names to "include" records.

--- a/api/tbFetchToolboxes.m
+++ b/api/tbFetchToolboxes.m
@@ -92,7 +92,7 @@ for tt = 1:nToolboxes
         
     else
         % toolbox is there already -- update it?
-        if strcmp(record.update, 'never')
+        if strcmp(record.update, 'never') || strcmp(prefs.update, 'never')
             if (prefs.verbose) fprintf('Found "%s" and skipping update.\n', displayName); end
         else
             if (prefs.verbose) fprintf('Updating "%s".\n', displayName); end

--- a/api/tbParsePrefs.m
+++ b/api/tbParsePrefs.m
@@ -36,6 +36,7 @@ function [prefs, others] = tbParsePrefs(varargin)
 %   - 'verbose' -- print out or shut up?
 %   - 'updateTbTb' -- whether to update TbTb from Github (logical)
 %   - 'updateRegistry' -- whether to update TbRegistry (logical)
+%   - 'update' -- whether to update all other toolboxes ('always'/'never')
 %
 % 2016-2017 benjamin.heasly@gmail.com
 
@@ -59,6 +60,7 @@ parser.addParameter('online', logical([]), @islogical);
 parser.addParameter('verbose', true, @islogical);
 parser.addParameter('updateTbTb', tbGetPref('updateTbTb', true), @islogical);
 parser.addParameter('updateRegistry', tbGetPref('updateRegistry', true), @islogical);
+parser.addParameter('update', tbGetPref('update', 'always'), @(f) any(strcmp(f, {'always' 'never'})));
 parser.parse(varargin{:});
 prefs = parser.Results;
 others = parser.Unmatched;

--- a/api/tbParsePrefs.m
+++ b/api/tbParsePrefs.m
@@ -35,6 +35,7 @@ function [prefs, others] = tbParsePrefs(varargin)
 %   - 'online' -- whether or not the Internet is reachable
 %   - 'verbose' -- print out or shut up?
 %   - 'updateTbTb' -- whether to update TbTb from Github (logical)
+%   - 'updateRegistry' -- whether to update TbRegistry (logical)
 %
 % 2016-2017 benjamin.heasly@gmail.com
 
@@ -57,6 +58,7 @@ parser.addParameter('remove', '', @ischar);
 parser.addParameter('online', logical([]), @islogical);
 parser.addParameter('verbose', true, @islogical);
 parser.addParameter('updateTbTb', tbGetPref('updateTbTb', true), @islogical);
+parser.addParameter('updateRegistry', tbGetPref('updateRegistry', true), @islogical);
 parser.parse(varargin{:});
 prefs = parser.Results;
 others = parser.Unmatched;

--- a/api/tbParsePrefs.m
+++ b/api/tbParsePrefs.m
@@ -34,6 +34,7 @@ function [prefs, others] = tbParsePrefs(varargin)
 %   - 'remove' -- how to tbResetMatlabPath() before deployment
 %   - 'online' -- whether or not the Internet is reachable
 %   - 'verbose' -- print out or shut up?
+%   - 'updateTbTb' -- whether to update TbTb from Github (logical)
 %
 % 2016-2017 benjamin.heasly@gmail.com
 
@@ -55,6 +56,7 @@ parser.addParameter('add', '', @ischar);
 parser.addParameter('remove', '', @ischar);
 parser.addParameter('online', logical([]), @islogical);
 parser.addParameter('verbose', true, @islogical);
+parser.addParameter('updateTbTb', tbGetPref('updateTbTb', true), @islogical);
 parser.parse(varargin{:});
 prefs = parser.Results;
 others = parser.Unmatched;

--- a/api/tbParsePrefs.m
+++ b/api/tbParsePrefs.m
@@ -50,7 +50,7 @@ parser.addParameter('configPath', tbGetPref('configPath', fullfile(tbUserFolder(
 parser.addParameter('asAssertion', false, @islogical);
 parser.addParameter('runLocalHooks', true, @islogical);
 parser.addParameter('addToPath', true, @islogical);
-parser.addParameter('reset', 'full', @(f) any(strcmp(f, {'full', 'no-matlab', 'no-self', 'bare', 'as-is'})));
+parser.addParameter('reset', tbGetPref('reset', 'full'), @(f) any(strcmp(f, {'full', 'no-matlab', 'no-self', 'bare', 'as-is'})));
 parser.addParameter('add', '', @ischar);
 parser.addParameter('remove', '', @ischar);
 parser.addParameter('online', logical([]), @islogical);


### PR DESCRIPTION
The purpose of this PRQ is to speedup and assure a predictable job of tbUse(). (See #90). A few preference params were added to avoid a constant updating from the server. The default behavior is still the same as before: always update to the newest version

Add prefs for updating the following toolboxes
* ToolboxToolbox ('updateTbTb')
* Registry ('updateRegistry')
* All other toolboxes ('update')

The first two takes a logical value, where the last one ('update') accepts 'always' and 'never'. This "inconsistency" is due to the fact that the "update" field in the json file also accepts 'never' as value

Furthermore, the reset behavior can now be defined via ```setpref()```. The current default 'full' is quite a bit slower and more invasive compared to 'as-is'

closes #90 
