### PR TITLE
add toolboxSubfolder preference

### DIFF
--- a/api/tbParsePrefs.m
+++ b/api/tbParsePrefs.m
@@ -21,6 +21,8 @@ function [prefs, others] = tbParsePrefs(varargin)
 %
 %   - 'toolboxRoot' -- where to put/look for normal toolboxes
 %   - 'toolboxCommonRoot' -- where to look for "pre-installed" toolboxes
+%   - 'toolboxSubfolder' -- which subfolder of <toolboxRoot> to put/look
+%                           for normal toolboxes
 %   - 'projectRoot' -- where to look for non-toolbox projects
 %   - 'localHookFolder' -- where to look for local hooks for each toolbox
 %   - 'checkInternetCommand' -- system() command to check for connectivity
@@ -48,6 +50,7 @@ parser.KeepUnmatched = true;
 parser.PartialMatching = false;
 parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
 parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
+parser.addParameter('toolboxSubfolder', '', @ischar);
 parser.addParameter('projectRoot', tbGetPref('projectRoot', fullfile(tbUserFolder(), 'projects')), @ischar);
 parser.addParameter('localHookFolder', tbGetPref('localHookFolder', fullfile(tbUserFolder(), 'localHookFolder')), @ischar);
 parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);

--- a/api/tbToolboxPath.m
+++ b/api/tbToolboxPath.m
@@ -41,4 +41,4 @@ else
 end
 
 % return a full path
-toolboxPath = fullfile(pathRoot, toolboxFolder);
+toolboxPath = fullfile(pathRoot, record.toolboxSubfolder, toolboxFolder);

--- a/api/tbToolboxRecord.m
+++ b/api/tbToolboxRecord.m
@@ -61,6 +61,7 @@ parser.addParameter('hook', '', @ischar);
 parser.addParameter('requirementHook', '', @ischar);
 parser.addParameter('localHookTemplate', '', @ischar);
 parser.addParameter('toolboxRoot', '', @ischar);
+parser.addParameter('toolboxSubfolder', '', @ischar);
 parser.addParameter('pathPlacement', 'append', @ischar);
 parser.addParameter('importance', '', @ischar);
 parser.addParameter('extra', '');


### PR DESCRIPTION
If the field \<toolboxSubfolder\> is set in a toolbox json config file,
the toolbox is stored in \<toolboxRoot\>/\<toolboxSubfolder\>

I can add a test method if desired, let me know where