### PR TITLE
Support subfolders for json files in the registry

### DIFF
--- a/api/tbSearchRegistry.m
+++ b/api/tbSearchRegistry.m
@@ -30,9 +30,14 @@ else
 end
 
 %% Check for the named configuration.
-registryContents = dir(registryPath);
-configFiles = {registryContents.name};
-configIndex = find(strcmpi(configFiles, [name '.json']), 1, 'first');
+canonicalName = regexprep(name, '[\\/]', filesep);
+subfolders = fileparts(canonicalName);
+folderConfigFile = fullfile(registryPath, subfolders);
+registryContents = dir(folderConfigFile);
+localConfigFiles = {registryContents.name};
+configFiles = cellfun(@(configFile)fullfile(subfolders, configFile), localConfigFiles, 'Uniform', false);
+
+configIndex = find(strcmpi(configFiles, [canonicalName '.json']), 1, 'first');
 if isempty(configIndex)
     configPath = '';
 else


### PR DESCRIPTION
The config file
<registryroot>\configurations\topic\subtopic\mytoolbox.json can be
deployed by ```tbUse('topic\subtopic\mytoolbox')```

Separators are translated to the current platform. This means
```tbUse('topic\toolbox')``` will also work on Linux
This is under the assumption that under Linux, filesep() and dir() have a consistent separator (which I did not test)