### PR TITLE
fix local hook if name contains folder

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -303,6 +303,12 @@ simpleHookExists = 2 == exist(simpleHookPath, 'file');
 explicitHookPath = fullfile(prefs.localHookFolder, [hookName 'LocalHook.m']);
 explicitHookExists = 2 == exist(explicitHookPath, 'file');
 
+%hookName might consist of subfolders
+explicitHookFolder = fileparts(explicitHookPath);
+if exist(explicitHookFolder, 'dir') == 0
+    mkdir(explicitHookFolder);
+end
+
 % create a local hook if missing and a template exists
 templatePath = fullfile(toolboxPath, record.localHookTemplate);
 templateExists = 2 == exist(templatePath, 'file');


### PR DESCRIPTION
If your toolbox name contains a subfolder, and you have a local hook,
make sure the subfolder is created in the local hook folder as well

Example json file
{
"name": "myproject/mytoolbox",
"localHookTemplate": "myhook.m"
}

The local hook myhook.m is now copied to
"...\MATLAB\localHookFolder\myproject\myhook..."

Before, the hook copy command failed since the target name contained
non-existing subfolders