### PR TITLE
add cdToFolder parameter

### DIFF
--- a/api/tbToolboxRecord.m
+++ b/api/tbToolboxRecord.m
@@ -42,6 +42,9 @@ function record = tbToolboxRecord(varargin)
 %   - 'java' relative path to jar files that should be added to the
 %   dynamic java class path. This can be a single string or an array of
 %   strings.
+%   - 'cdToFolder' If set, change working dir to the specified subfolder of
+%                  the toolbox root. If you want to change to the root dir,
+%                  you must specify the current relative folder '.'
 %
 % 2016 benjamin.heasly@gmail.com
 
@@ -66,6 +69,7 @@ parser.addParameter('pathPlacement', 'append', @ischar);
 parser.addParameter('importance', '', @ischar);
 parser.addParameter('extra', '');
 parser.addParameter('java','',@ischar);
+parser.addParameter('cdToFolder', '', @ischar);
 parser.parse(varargin{:});
 
 % Let the parser do all the work

--- a/api/tbUse.m
+++ b/api/tbUse.m
@@ -30,3 +30,9 @@ if ischar(registered)
 end
 
 results = tbDeployToolboxes(prefs, 'registered', registered);
+
+if ~isempty(results) && ~isempty(results(1).cdToFolder)
+    fdr = fullfile(tbLocateToolbox(results(1).name), results(1).cdToFolder);
+    fprintf('Changing to %s\n', fdr);
+    cd(fdr)
+end


### PR DESCRIPTION
I use not only toolboxes, but also projects via my own ToolboxRegistry. It would be handy to cd into a specified folder when you work on the project. This parameter exists for tbUseProject(), but not for tbUse(). This PRQ adds the possibility to add a "cdToFolder" property in the json file