### PR TITLE
tbGetToolboxNames

### DIFF
--- a/api/tbGetToolboxNames.m
+++ b/api/tbGetToolboxNames.m
@@ -1,0 +1,41 @@
+function s = tbGetToolboxNames
+%TBGETTOOLBOXNAMES Get struct containing the toolbox names
+%
+%  names = tbGetToolboxNames() returns a struct where each field
+%  corresponds to a toolbox. The field contains the toolbox name as a char
+%  array.
+%
+%  The result is populated by parsing the configurations directory of the
+%  ToolboxRegistry. Subfolders are handled correctly.
+%
+%  2019 Markus Leuthold (github@titlis.org)
+
+prefs = tbParsePrefs;
+registryRoot = tbLocateToolbox(prefs.registry);
+configRoot = fullfile(registryRoot, prefs.registry.subfolder);
+
+s = getNamesRecursively(struct, configRoot, configRoot);
+
+function s = getNamesRecursively(s, curPath, configRoot)
+dAll = dir(curPath);
+d = dAll(~startsWith({dAll.name}, '.'));
+
+for k = find([d.isdir])
+    curIdentifier = getNamesRecursively(s, fullfile(d(k).folder, d(k).name), configRoot);
+    s.(d(k).name) = curIdentifier;
+end
+
+for k = find(~[d.isdir])
+    %strip extension
+    [~, name] = fileparts(d(k).name);
+    
+    %strip root
+    base = erase(d(k).folder, configRoot);
+    
+    %delete slash at the beginning, if any
+    base = regexprep(base, ['^\' filesep], '');
+    
+    identifier = fullfile(base, name);
+    s.(matlab.lang.makeValidName(name)) = identifier;
+end
+


### PR DESCRIPTION
Provide the toolbox identifiers as struct. This allows to tbUse() by
means of tab-completion:

Example

    tbNames = tbGetToolboxNames;
    tbUse(tbNames.matlabcentral_demo)

Note that after ```tbNames.``` you can use tab-completion

This is especially handy if you have your own ToolboxRegistry,
containing subfolders or if you want to have an overview on the Matlab
command line what toolboxes exist