### PR TITLE
speedup tbParsePrefs (persistent prefs)

### DIFF
--- a/api/tbAddToolbox.m
+++ b/api/tbAddToolbox.m
@@ -1,4 +1,4 @@
-function results = tbAddToolbox(varargin)
+function results = tbAddToolbox(persistentPrefs, varargin)
 % Add a toolbox to the toolbox configuration, fetch it, add it to the path.
 %
 % The goal here is to make it a one-liner to add a new toolbox to the
@@ -17,7 +17,7 @@ function results = tbAddToolbox(varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-[prefs, others] = tbParsePrefs(varargin{:});
+[prefs, others] = tbParsePrefs(persistentPrefs, varargin{:});
 
 %% Make a new toolbox record.
 newRecord = tbToolboxRecord(others);
@@ -34,7 +34,7 @@ if 0 ~= results.status
 end
 
 %% Add new toolbox to the existing config.
-config = tbReadConfig(prefs);
+config = tbReadConfig(persistentPrefs, prefs);
 if isempty(config) || ~isstruct(config) || ~isfield(config, 'name')
     config = newRecord;
 else
@@ -48,5 +48,5 @@ else
 end
 
 %% Write back the new config. after success.
-tbWriteConfig(config, prefs);
+tbWriteConfig(config, persistentPrefs, prefs);
 

--- a/api/tbCheckInternet.m
+++ b/api/tbCheckInternet.m
@@ -1,4 +1,4 @@
-function [isOnline, result] = tbCheckInternet(varargin)
+function [isOnline, result] = tbCheckInternet(persistentPrefs, varargin)
 % Check with the operating system whether the Intenet is reachable.
 %
 % The idea is to check for Internet connectivity with a simple command that
@@ -16,7 +16,7 @@ function [isOnline, result] = tbCheckInternet(varargin)
 % 2016 benjamin.heasly@gmail.com
 
 % supply a value for "online" to prevent infinite recusive check
-[prefs, others] = tbParsePrefs(varargin{:}, 'online', false);
+[prefs, others] = tbParsePrefs(persistentPrefs, varargin{:}, 'online', false);
 
 % caller wants to skip the check?
 if isempty(prefs.checkInternetCommand)

--- a/api/tbCurrentPrefs.m
+++ b/api/tbCurrentPrefs.m
@@ -1,4 +1,4 @@
-function prefs = tbCurrentPrefs(varargin)
+function prefs = tbCurrentPrefs(persistentPrefs, varargin)
 % Set or get the current working ToolboxToolbox preferences.
 %
 % This function gives a way to share the current, working ToolboxToolbox
@@ -17,11 +17,11 @@ function prefs = tbCurrentPrefs(varargin)
 %
 % 2016-2017 benjamin.heasly@gmail.com
 
-persistent persistentPrefs
+persistent PREFS
 
 if nargin > 0
     % store the given prefs
-    persistentPrefs = tbParsePrefs(varargin{:});
+    PREFS = tbParsePrefs(persistentPrefs, varargin{:});
 end
 
-prefs = persistentPrefs;
+prefs = PREFS;

--- a/api/tbDeployToFolder.m
+++ b/api/tbDeployToFolder.m
@@ -50,4 +50,4 @@ config = tbDealField(config, 'toolboxRoot', prefs.toolboxRoot);
 
 
 %% The rest of the deployment is the same as usual.
-results = tbDeployToolboxes('config', config, prefs);
+results = tbDeployToolboxes(persistentPrefs, 'config', config, prefs);

--- a/api/tbDeploymentSnapshot.m
+++ b/api/tbDeploymentSnapshot.m
@@ -1,4 +1,4 @@
-function snapshot = tbDeploymentSnapshot(config, varargin)
+function snapshot = tbDeploymentSnapshot(config, persistentPrefs, varargin)
 % Make a new config based on the given config, plus explicit flavors.
 %
 % The idea is to take an existing toolbox configuration and create a new
@@ -36,7 +36,7 @@ nToolboxes = numel(config);
 snapshotCell = cell(1, nToolboxes);
 for tt = 1:nToolboxes
     record = config(tt);
-    strategy = tbChooseStrategy(record, prefs);
+    strategy = tbChooseStrategy(record, persistentPrefs, prefs);
     
     if isempty(strategy)
         continue;
@@ -56,7 +56,7 @@ systemInfo.matlab_ver = evalc('ver');
 systemInfo.java = version('-java');
 systemInfo.computer = computer();
 systemInfo.toolboxRegistry = getRegistryInfo(prefs);
-systemInfo.toolboxToolbox = getSelfInfo(prefs);
+systemInfo.toolboxToolbox = getSelfInfo(persistentPrefs, prefs);
 
 % store in an empty toolbox record, to be ignored during deployment
 systemRecord = tbToolboxRecord( ...
@@ -77,12 +77,12 @@ registryInfo = tbToolboxRecord(registry, 'flavor', flavor);
 
 
 %% Try to detect the ToolboxToolbox flavor, assuming it's with Git.
-function selfInfo = getSelfInfo(prefs)
+function selfInfo = getSelfInfo(persistentPrefs, prefs)
 self = tbToolboxRecord( ...
     'toolboxRoot', fileparts(tbLocateSelf()), ...
     'name', 'ToolboxToolbox', ...
     'type', 'git');
-strategy = tbChooseStrategy(self, prefs);
+strategy = tbChooseStrategy(self, persistentPrefs, prefs);
 flavor = strategy.detectFlavor(self);
 url = strategy.detectOriginUrl(self);
 selfInfo = tbToolboxRecord(self, 'flavor', flavor, 'url', url);

--- a/api/tbFetchRegistry.m
+++ b/api/tbFetchRegistry.m
@@ -1,4 +1,4 @@
-function results = tbFetchRegistry(varargin)
+function results = tbFetchRegistry(persistentPrefs, varargin)
 % Obtain or update a registry of shared toolbox configurations.
 %
 % The goal here is to make it a one-liner to obtain or update a registry of
@@ -18,7 +18,7 @@ function results = tbFetchRegistry(varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-[prefs, others] = tbParsePrefs(varargin{:});
+[prefs, others] = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addParameter('doUpdate', true, @islogical);
@@ -31,5 +31,5 @@ if ~doUpdate
 end
 
 %% Obtain or update just like a toolbox.
-results = tbFetchToolboxes(prefs.registry, prefs);
+results = tbFetchToolboxes(prefs.registry, persistentPrefs, prefs);
 

--- a/api/tbFetchToolboxes.m
+++ b/api/tbFetchToolboxes.m
@@ -1,4 +1,4 @@
-function results = tbFetchToolboxes(config, varargin)
+function results = tbFetchToolboxes(config, persistentPrefs, varargin)
 % Read toolbox configuration from a file.
 %
 % The idea is to work through elements of the given toolbox configuration
@@ -17,7 +17,7 @@ function results = tbFetchToolboxes(config, varargin)
 % 6/24/17  dhb  Add # syntax for dealing with projects that we want to
 %               treat as toolboxes, while also treating them as independent projects.
 
-prefs = tbParsePrefs(varargin{:});
+prefs = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('config', @isstruct);
@@ -44,7 +44,7 @@ for tt = 1:nToolboxes
     end
     
     % what kind of toolbox is this?
-    strategy = tbChooseStrategy(record, prefs);
+    strategy = tbChooseStrategy(record, persistentPrefs, prefs);
     if isempty(strategy)
         results(tt).status = -1;
         results(tt).command = 'tbChooseStrategy';

--- a/api/tbGetPersistentPrefs.m
+++ b/api/tbGetPersistentPrefs.m
@@ -1,0 +1,2 @@
+function persistentPrefs = tbGetPersistentPrefs
+persistentPrefs = getpref('ToolboxToolbox');

--- a/api/tbGetPref.m
+++ b/api/tbGetPref.m
@@ -1,4 +1,4 @@
-function value = tbGetPref(preferenceName, defaultValue)
+function value = tbGetPref(persistentPrefs, preferenceName, defaultValue)
 %% Get a preference if it exists, or use a default.
 %
 % value = tbGetPref(preferenceName, defaultValue) returns the
@@ -19,8 +19,8 @@ parser.parse(preferenceName, defaultValue);
 preferenceName = parser.Results.preferenceName;
 defaultValue = parser.Results.defaultValue;
 
-if ispref('ToolboxToolbox', preferenceName)
-    value = getpref('ToolboxToolbox', preferenceName);
+if isfield(persistentPrefs, preferenceName)
+    value = persistentPrefs.(preferenceName);
 else
     value = defaultValue;
 end

--- a/api/tbGetToolboxNames.m
+++ b/api/tbGetToolboxNames.m
@@ -10,7 +10,7 @@ function s = tbGetToolboxNames
 %
 %  2019 Markus Leuthold (github@titlis.org)
 
-prefs = tbParsePrefs;
+prefs = tbParsePrefs(tbGetPersistentPrefs);
 registryRoot = tbLocateToolbox(prefs.registry);
 configRoot = fullfile(registryRoot, prefs.registry.subfolder);
 

--- a/api/tbLocateProject.m
+++ b/api/tbLocateProject.m
@@ -1,4 +1,4 @@
-function [projectPath, configPath, projectParent] = tbLocateProject(project, varargin)
+function [projectPath, configPath, projectParent] = tbLocateProject(project, persistentPrefs, varargin)
 % Locate the folder that contains the given project.
 %
 % projectPath = tbLocateProject(name) locates the project with the given
@@ -13,7 +13,11 @@ function [projectPath, configPath, projectParent] = tbLocateProject(project, var
 %
 % 2016 benjamin.heasly@gmail.com
 
-[prefs, others] = tbParsePrefs(varargin{:});
+if nargin == 1
+    persistentPrefs = tbGetPersistentPrefs;
+end
+
+[prefs, others] = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('project', @(val) ischar(val) || isstruct(val));

--- a/api/tbLocateToolbox.m
+++ b/api/tbLocateToolbox.m
@@ -1,4 +1,4 @@
-function [toolboxPath, displayName, toolboxRoot] = tbLocateToolbox(toolbox, varargin)
+function [toolboxPath, displayName, toolboxRoot] = tbLocateToolbox(toolbox, persistentPrefs, varargin)
 % Locate the folder that contains the given toolbox.
 %
 % toolboxPath = tbLocateToolbox(name) locates the toolbox with the given
@@ -13,7 +13,11 @@ function [toolboxPath, displayName, toolboxRoot] = tbLocateToolbox(toolbox, vara
 %
 % 2016 benjamin.heasly@gmail.com
 
-[prefs, others] = tbParsePrefs(varargin{:});
+if nargin == 1
+    persistentPrefs = tbGetPersistentPrefs;
+end
+
+[prefs, others] = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('toolbox', @(val) ischar(val) || isstruct(val));
@@ -26,7 +30,7 @@ if ischar(toolbox)
 else
     record = toolbox;
 end
-strategy = tbChooseStrategy(record, prefs);
+strategy = tbChooseStrategy(record, persistentPrefs, prefs);
 
 % first, look for a toolbox or project in its own, explicit location
 if ~isempty(record.toolboxRoot)

--- a/api/tbParsePrefs.m
+++ b/api/tbParsePrefs.m
@@ -1,4 +1,4 @@
-function [prefs, others] = tbParsePrefs(varargin)
+function [prefs, others] = tbParsePrefs(persistentPrefs, varargin)
 % Parse out ToolboxToolbox shared parameters and preferences.
 %
 % The idea here is to have one place where we parse parameters and check
@@ -46,34 +46,36 @@ function [prefs, others] = tbParsePrefs(varargin)
 %
 % 2016-2017 benjamin.heasly@gmail.com
 
+
+
 parser = inputParser();
 parser.KeepUnmatched = true;
 parser.PartialMatching = false;
-parser.addParameter('toolboxRoot', tbGetPref('toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
-parser.addParameter('toolboxCommonRoot', tbGetPref('toolboxCommonRoot', '/srv/toolboxes'), @ischar);
+parser.addParameter('toolboxRoot', tbGetPref(persistentPrefs, 'toolboxRoot', fullfile(tbUserFolder(), 'toolboxes')), @ischar);
+parser.addParameter('toolboxCommonRoot', tbGetPref(persistentPrefs, 'toolboxCommonRoot', '/srv/toolboxes'), @ischar);
 parser.addParameter('toolboxSubfolder', '', @ischar);
-parser.addParameter('projectRoot', tbGetPref('projectRoot', fullfile(tbUserFolder(), 'projects')), @ischar);
-parser.addParameter('localHookFolder', tbGetPref('localHookFolder', fullfile(tbUserFolder(), 'localHookFolder')), @ischar);
-parser.addParameter('checkInternetCommand', tbGetPref('checkInternetCommand', ''), @ischar);
-parser.addParameter('registry', tbGetPref('registry', tbDefaultRegistry()), @(c) isempty(c) || isstruct(c));
-parser.addParameter('configPath', tbGetPref('configPath', fullfile(tbUserFolder(), 'toolbox_config.json')), @ischar);
+parser.addParameter('projectRoot', tbGetPref(persistentPrefs, 'projectRoot', fullfile(tbUserFolder(), 'projects')), @ischar);
+parser.addParameter('localHookFolder', tbGetPref(persistentPrefs, 'localHookFolder', fullfile(tbUserFolder(), 'localHookFolder')), @ischar);
+parser.addParameter('checkInternetCommand', tbGetPref(persistentPrefs, 'checkInternetCommand', ''), @ischar);
+parser.addParameter('registry', tbGetPref(persistentPrefs, 'registry', tbDefaultRegistry()), @(c) isempty(c) || isstruct(c));
+parser.addParameter('configPath', tbGetPref(persistentPrefs, 'configPath', fullfile(tbUserFolder(), 'toolbox_config.json')), @ischar);
 parser.addParameter('asAssertion', false, @islogical);
 parser.addParameter('runLocalHooks', true, @islogical);
-parser.addParameter('printLocalHookOutput', logical(tbGetPref('printLocalHookOutput', 0)), @(x) (islogical(x) || ischar(x)));
+parser.addParameter('printLocalHookOutput', logical(tbGetPref(persistentPrefs, 'printLocalHookOutput', 0)), @(x) (islogical(x) || ischar(x)));
 parser.addParameter('addToPath', true, @islogical);
-parser.addParameter('reset', tbGetPref('reset', 'full'), @(f) any(strcmp(f, {'full', 'no-matlab', 'no-self', 'bare', 'as-is'})));
+parser.addParameter('reset', tbGetPref(persistentPrefs, 'reset', 'full'), @(f) any(strcmp(f, {'full', 'no-matlab', 'no-self', 'bare', 'as-is'})));
 parser.addParameter('add', '', @ischar);
 parser.addParameter('remove', '', @ischar);
 parser.addParameter('online', logical([]), @islogical);
-parser.addParameter('verbose', tbGetPref('verbose', true), @islogical);
-parser.addParameter('checkTbTb', tbGetPref('checkTbTb', true), @islogical);
-parser.addParameter('updateRegistry', tbGetPref('updateRegistry', true), @islogical);
-parser.addParameter('update', tbGetPref('update', 'asspecified'), @(f) (isempty(f) | any(strcmp(f, {'asspecified' 'never'}))));
+parser.addParameter('verbose', tbGetPref(persistentPrefs, 'verbose', true), @islogical);
+parser.addParameter('checkTbTb', tbGetPref(persistentPrefs, 'checkTbTb', true), @islogical);
+parser.addParameter('updateRegistry', tbGetPref(persistentPrefs, 'updateRegistry', true), @islogical);
+parser.addParameter('update', tbGetPref(persistentPrefs, 'update', 'asspecified'), @(f) (isempty(f) | any(strcmp(f, {'asspecified' 'never'}))));
 parser.parse(varargin{:});
 prefs = parser.Results;
 others = parser.Unmatched;
 
 % if "online" not give explicitly, check for the Internet
 if isempty(prefs.online)
-    prefs.online = tbCheckInternet(prefs);
+    prefs.online = tbCheckInternet(persistentPrefs, prefs);
 end

--- a/api/tbReadConfig.m
+++ b/api/tbReadConfig.m
@@ -1,4 +1,4 @@
-function [config, configPath] = tbReadConfig(varargin)
+function [config, configPath] = tbReadConfig(persistentPrefs, varargin)
 % Read toolbox configuration from a file.
 %
 % The idea is to locate a toolbox configuration file on disk, and load it
@@ -14,7 +14,7 @@ function [config, configPath] = tbReadConfig(varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-prefs = tbParsePrefs(varargin{:});
+prefs = tbParsePrefs(persistentPrefs, varargin{:});
 configPath = prefs.configPath;
 config = [];
 

--- a/api/tbResetMatlabPath.m
+++ b/api/tbResetMatlabPath.m
@@ -38,11 +38,13 @@ function [newPath, oldPath] = tbResetMatlabPath(varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
+persistentPrefs = tbGetPersistentPrefs;
+
 if 1 == nargin() && ischar(varargin{1})
     % support legacy syntax: tbParsePrefs(reset)
-    prefs = tbParsePrefs('reset', varargin{1});
+    prefs = tbParsePrefs(persistentPrefs, 'reset', varargin{1});
 else
-    prefs = tbParsePrefs(varargin{:});
+    prefs = tbParsePrefs(persistentPrefs, varargin{:});
 end
 
 

--- a/api/tbSearchRegistry.m
+++ b/api/tbSearchRegistry.m
@@ -1,4 +1,4 @@
-function configPath = tbSearchRegistry(name, varargin)
+function configPath = tbSearchRegistry(name, persistentPrefs, varargin)
 % Search a registry for a configuration with the givne name.
 %
 % configPath = tbFetchRegistry(name) searches the default ToolboxHub
@@ -10,7 +10,7 @@ function configPath = tbSearchRegistry(name, varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-prefs = tbParsePrefs(varargin{:});
+prefs = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('name', @ischar);
@@ -18,7 +18,7 @@ parser.parse(name);
 name = parser.Results.name;
 
 %% Locate the folder that contains the registry.
-registryBasePath = tbLocateToolbox(prefs.registry, prefs);
+registryBasePath = tbLocateToolbox(prefs.registry, persistentPrefs, prefs);
 
 % only use first registry subfolder, if any
 if ischar(prefs.registry.subfolder)

--- a/api/tbUse.m
+++ b/api/tbUse.m
@@ -17,7 +17,8 @@ function results = tbUse(registered, varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-prefs = tbParsePrefs(varargin{:});
+persistentPrefs = tbGetPersistentPrefs;
+prefs = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('registered', @(r) ischar(r) || iscellstr(r));
@@ -29,7 +30,7 @@ if ischar(registered)
     registered = {registered};
 end
 
-results = tbDeployToolboxes(prefs, 'registered', registered);
+results = tbDeployToolboxes(persistentPrefs, prefs, 'registered', registered);
 
 if ~isempty(results) && ~isempty(results(1).cdToFolder)
     fdr = fullfile(tbLocateToolbox(results(1).name), results(1).cdToFolder);

--- a/api/tbUseProject.m
+++ b/api/tbUseProject.m
@@ -15,7 +15,8 @@ function results = tbUseProject(name, varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-[prefs, others] = tbParsePrefs(varargin{:});
+persistentPrefs = tbGetPersistentPrefs;
+[prefs, others] = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('name', @ischar);
@@ -50,4 +51,4 @@ if any(isProject)
     [config(isProject).toolboxRoot] = deal(projectParent);
 end
 
-results = tbDeployToolboxes('config', config, prefs);
+results = tbDeployToolboxes(persistentPrefs, 'config', config, prefs);

--- a/api/tbWriteConfig.m
+++ b/api/tbWriteConfig.m
@@ -14,7 +14,8 @@ function configPath = tbWriteConfig(config, varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-prefs = tbParsePrefs(varargin{:});
+
+prefs = tbParsePrefs(tbGetPersistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('config', @isstruct);

--- a/strategies/TbIncludeStrategy.m
+++ b/strategies/TbIncludeStrategy.m
@@ -35,7 +35,7 @@ classdef TbIncludeStrategy < TbToolboxStrategy
     
     methods (Static)
         % Iterate the given config, resolve and append new records as they come.
-        function [resolved, includes] = resolveIncludedConfigs(config, prefs)           
+        function [resolved, includes] = resolveIncludedConfigs(persistentPrefs, config, prefs)           
             if isempty(config)
                 resolved = [];
                 includes = [];
@@ -63,7 +63,7 @@ classdef TbIncludeStrategy < TbToolboxStrategy
                 
                 if ~isempty(url)
                     % append the included config so it can be resolved
-                    newConfig = tbReadConfig(prefs, 'configPath', url);
+                    newConfig = tbReadConfig(persistentPrefs, prefs, 'configPath', url);
                     if isempty(newConfig) || ~isstruct(newConfig) || ~isfield(newConfig, 'name')
                         continue;
                     end

--- a/strategies/TbToolboxStrategy.m
+++ b/strategies/TbToolboxStrategy.m
@@ -14,7 +14,7 @@ classdef TbToolboxStrategy < handle
     % 2016 benjamin.heasly@gmail.com
     
     properties
-        prefs = tbParsePrefs();
+        prefs
     end
     
     methods (Abstract)
@@ -23,6 +23,10 @@ classdef TbToolboxStrategy < handle
     end
     
     methods
+        function obj = TbToolboxStrategy(persistentPrefs)
+            obj.prefs = tbParsePrefs(persistentPrefs);
+        end
+        
         function [toolboxPath, displayName] = toolboxPath(obj, toolboxRoot, record)
             % default: standard folder inside given toolboxRoot
             [toolboxPath, displayName] = tbToolboxPath(toolboxRoot, record);

--- a/strategies/tbChooseStrategy.m
+++ b/strategies/tbChooseStrategy.m
@@ -1,4 +1,4 @@
-function strategy = tbChooseStrategy(record, varargin)
+function strategy = tbChooseStrategy(record, persistentPrefs, varargin)
 % Choose a TbToolboxStrategy appropriate for the given toolbox record.
 %
 % strategy = tbChooseStrategy(record) chooses an implementaton of
@@ -16,7 +16,7 @@ function strategy = tbChooseStrategy(record, varargin)
 %
 % 2016 benjamin.heasly@gmail.com
 
-prefs = tbParsePrefs(varargin{:});
+prefs = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
 parser.addRequired('record', @isstruct);
@@ -33,22 +33,22 @@ end
 %% Check the short list of recognized types.
 switch record.type
     case 'git'
-        strategy = TbGitStrategy();
+        strategy = TbGitStrategy(persistentPrefs);
     case 'svn'
-        strategy = TbSvnStrategy();
+        strategy = TbSvnStrategy(persistentPrefs);
     case 'webget'
-        strategy = TbWebGetStrategy();
+        strategy = TbWebGetStrategy(persistentPrefs);
     case 'local'
-        strategy = TbLocalStrategy();
+        strategy = TbLocalStrategy(persistentPrefs);
     case 'installed'
-        strategy = TbInstalledStrategy();
+        strategy = TbInstalledStrategy(persistentPrefs);
     case 'docker'
-        strategy = TbDockerStrategy();
+        strategy = TbDockerStrategy(persistentPrefs);
     case 'include'
-        strategy = TbIncludeStrategy();
+        strategy = TbIncludeStrategy(persistentPrefs);
     otherwise
         % default to "include", for easy shorthand
-        strategy = TbIncludeStrategy();
+        strategy = TbIncludeStrategy(persistentPrefs);
 end
 
 


### PR DESCRIPTION
The slow command getpref('ToolboxToolbox') is on a performance-critical path.
Therefore a significant performance gain (54% in my particular case) can
be gained by injecting the result of getpref() to each function

While this PRQ is not too complex, it is quite invasive as it has to add a new parameter for many functions. I did not yet update the tests. I'm happy to do so, but please let me know first what you think of it.

I successfully use this change already for many months.