### PR TITLE
tbWriteConfig doesn't take persistent prefs

### DIFF
--- a/api/tbAddToolbox.m
+++ b/api/tbAddToolbox.m
@@ -48,5 +48,5 @@ else
 end
 
 %% Write back the new config. after success.
-tbWriteConfig(config, persistentPrefs, prefs);
+tbWriteConfig(config, prefs);
 


### PR DESCRIPTION
Since tbWriteConfig is not time critical, there's no need to pass a
persistent prefs arg, but just use getprefs('ToolboxToolbox').

Despite that, a persistent pref arg was provided. As long as it's not
empty, this doesn't matter since "prefs" wins over "persistentPrefs".
However, if persistentPrefs is empty, this fails.