### PR TITLE
Deploy only once

### DIFF
--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -143,6 +143,15 @@ if isempty(resolved)
     end
 end
 
+%% remove toolbox if already deployed
+if prefs.useOnce && isequal(prefs.reset, 'as-is')
+    isDeployed = ismember({resolved.name}, tbDeployedToolboxes);
+    if any(isDeployed)
+        disp('The following toolboxes have already been deployed')
+        disp({resolved(isDeployed).name}');
+        resolved = resolved(~isDeployed);
+    end
+end
 
 %% Obtain or update the toolboxes.
 if ~isempty(resolved)
@@ -192,6 +201,9 @@ if prefs.addToPath
                 javaaddpath(fullfile(toolboxPath,jarfiles{jj}));
             end
         end
+        
+        % Mark toolbox as deployed
+        tbDeployedToolboxes(record.name, 'append');
     end
 end
 

--- a/api/tbDeployToolboxes.m
+++ b/api/tbDeployToolboxes.m
@@ -220,10 +220,12 @@ if prefs.runLocalHooks
         resolved(tt) = invokeLocalHook(resolved(tt), persistentPrefs, prefs);
     end
     
-    % included toolboxes that were not deployed but might have local hooks anyway
-    alreadyRun = ismember(tbCollectField(included, 'name', 'template', {}), tbCollectField(resolved, 'name', 'template', {}));
-    for tt = find(~alreadyRun)
-        included(tt) = invokeLocalHook(included(tt), persistentPrefs, prefs);
+    if ~(prefs.useOnce && isequal(prefs.reset, 'as-is'))
+        % included toolboxes that were not deployed but might have local hooks anyway
+        alreadyRun = ismember(tbCollectField(included, 'name', 'template', {}), tbCollectField(resolved, 'name', 'template', {}));
+        for tt = find(~alreadyRun)
+            included(tt) = invokeLocalHook(included(tt), persistentPrefs, prefs);
+        end
     end
 end
 

--- a/api/tbDeployedToolboxes.m
+++ b/api/tbDeployedToolboxes.m
@@ -1,0 +1,61 @@
+function toolboxNames = tbDeployedToolboxes(toolboxNames, cmd)
+% TBDEPLOYEDTOOLBOXES Check if toolbox was already deployed previously
+%
+%    deployedToolboxNames = tbDeployedToolboxes()
+%       return cell of toolbox names which are already deployed
+%
+%    deployedToolboxNames = tbDeployedToolboxes(toolboxNames, 'append')
+%       Add <toolboxNames> to the list of deployed toolboxes
+%
+%    deployedToolboxNames = tbDeployedToolboxes(toolboxNames, 'reset')
+%       Set only <toolboxNames> as list of deployed toolboxes
+%
+%    deployedToolboxNames = tbDeployedToolboxes(toolboxNames, 'remove')
+%       Remove <toolboxNames> from list of deployed toolboxes
+%
+%    toolboxNames = tbDeployedToolboxes
+%       Get all deployed toolbox names
+%
+%    This only works as long as packages are deployed by tbUse() and the
+%    Matlab path is not modified manually
+
+
+% A "clear all" command has no effect on the matlab path. Therefore make
+% sure TOOLBOXES is never cleared during a Matlab session
+mlock
+
+persistent TOOLBOXES
+if isempty(TOOLBOXES)
+    TOOLBOXES = {};
+end
+
+if nargout == 0
+    % write
+    
+    if ischar(toolboxNames)
+        toolboxNames = {toolboxNames};
+    end
+    
+    if isempty(toolboxNames)
+        toolboxNames = {};
+    end
+    
+    switch cmd
+        case 'append'
+            TOOLBOXES = [TOOLBOXES reshape(toolboxNames, 1, [])];
+            
+        case 'reset'
+            % overwrite
+            TOOLBOXES = reshape(toolboxNames, 1, []);
+            
+        case 'remove'
+            TOOLBOXES = setdiff(TOOLBOXES, toolboxNames);
+            
+        otherwise
+            error('wrong command')
+    end
+    
+else
+    % read
+    toolboxNames = TOOLBOXES;
+end

--- a/api/tbParsePrefs.m
+++ b/api/tbParsePrefs.m
@@ -43,6 +43,9 @@ function [prefs, others] = tbParsePrefs(persistentPrefs, varargin)
 %                 'asspecified' (default) follows what is specified in the
 %                 update field of the toolbox record. 'never' overrides
 %                 that field and does not update any of the toolboxes.
+%   - 'useOnce' -- whether to skip the deployment if the toolbox was
+%                  already deployed during the current Matlab session. This
+%                  only has an effect if 'reset' == 'as-is'
 %
 % 2016-2017 benjamin.heasly@gmail.com
 
@@ -71,6 +74,7 @@ parser.addParameter('verbose', tbGetPref(persistentPrefs, 'verbose', true), @isl
 parser.addParameter('checkTbTb', tbGetPref(persistentPrefs, 'checkTbTb', true), @islogical);
 parser.addParameter('updateRegistry', tbGetPref(persistentPrefs, 'updateRegistry', true), @islogical);
 parser.addParameter('update', tbGetPref(persistentPrefs, 'update', 'asspecified'), @(f) (isempty(f) | any(strcmp(f, {'asspecified' 'never'}))));
+parser.addParameter('useOnce', tbGetPref(persistentPrefs, 'useOnce', false), @islogical)
 parser.parse(varargin{:});
 prefs = parser.Results;
 others = parser.Unmatched;

--- a/api/tbResetMatlabPath.m
+++ b/api/tbResetMatlabPath.m
@@ -63,6 +63,8 @@ addMatlab = strcmp(prefs.add, 'matlab');
 
 %% Start with Matlab's consistent "factory" path.
 if factoryReset
+    tbDeployedToolboxes({}, 'reset')
+    
     % This was an attempt to prevent barfing because there
     % are java objects hanging around somewhere.  Might not
     % be sufficient. But it also clears the preferences, becasue


### PR DESCRIPTION
If a toolbox was already deployed, don't deploy it another time during the current Matlab sessin since
most likely, the Matlab path is still correct.

This allows to keep tbUse('yourproject', 'useOnce', true) in your script without the need to comment it out if executed consecutively. Or changing between projects with similar dependencies does not trigger a re-deployment of toolboxes

* Ignore useOnce if reset is not 'as-is'
* Default is useOnce == false

Caveats
* This only works if the Matlab path is set via ToolboxToolbox. If the Matlab path is altered outside ToolboxToolbox, the persistent variable in tbDeployedToolboxes() wouldn't get updated
* If you set useOnce=true in your Matlab preferences via setpref(), a bunch of unit tests will fail. However, if you don't set useOnce, the behavior with this PRQ doesn't change at all
