### PR TITLE
Improve argument input

### DIFF
--- a/api/+tbtb/+internal/+functionSignatures/getToolboxNames.m
+++ b/api/+tbtb/+internal/+functionSignatures/getToolboxNames.m
@@ -1,0 +1,2 @@
+function s = getToolboxNames
+[~, s] = tbGetToolboxNames;

--- a/api/functionSignatures.json
+++ b/api/functionSignatures.json
@@ -1,0 +1,20 @@
+{
+"tbUse":
+{
+    "inputs":
+    [
+        {"name":"ToolboxName", "kind":"required", "type":["choices=tbtb.internal.functionSignatures.getToolboxNames"]},
+        {"name":"reset", "kind":"namevalue", "type":["choices={'full', 'no-matlab', 'no-self', 'bare', 'as-is'}"]},
+        {"name":"useOnce", "kind":"namevalue", "type":["logical", "scalar"]},
+        {"name":"cdToFolder", "kind":"namevalue", "type":["logical", "scalar"]}
+    ]     
+},
+
+"tbLocateToolbox":
+{
+    "inputs":
+    [
+        {"name":"ToolboxName", "kind":"required", "type":["choices=tbtb.internal.functionSignatures.getToolboxNames"]}
+    ]
+}
+}

--- a/api/tbLocateToolbox.m
+++ b/api/tbLocateToolbox.m
@@ -20,9 +20,13 @@ end
 [prefs, others] = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
-parser.addRequired('toolbox', @(val) ischar(val) || isstruct(val));
+parser.addRequired('toolbox', @(val) ischar(val) || isstruct(val) || isstring(val));
 parser.parse(toolbox);
 toolbox = parser.Results.toolbox;
+
+if isstring(toolbox)
+    toolbox = char(toolbox);
+end
 
 % convert convenient string to general toolbox record
 if ischar(toolbox)

--- a/api/tbUse.m
+++ b/api/tbUse.m
@@ -21,9 +21,13 @@ persistentPrefs = tbGetPersistentPrefs;
 prefs = tbParsePrefs(persistentPrefs, varargin{:});
 
 parser = inputParser();
-parser.addRequired('registered', @(r) ischar(r) || iscellstr(r));
+parser.addRequired('registered', @(r) ischar(r) || iscellstr(r) || isstring(r));
 parser.parse(registered);
 registered = parser.Results.registered;
+
+if isstring(registered)
+    registered = registered.cellstr;
+end
 
 % convert convenient string form to general list form
 if ischar(registered)


### PR DESCRIPTION
Recently, Matlab introduced a configurable tab completion mechanism base on functionSignature.json files. Implement parameter tab completion for tbUse() and tbLocateToolbox(). Default type for text is string, therefore also add support for string input. Everything works fine with char, though.
This PRQ needs at least Matlab 2016b. Although the completion stuff only works with newer Matlab versions, it's just being ignored with a too old Matlab version and hence doesn't hurt.